### PR TITLE
Set white site background

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -7,8 +7,8 @@
 }
 body {
     font-family: 'Arial', sans-serif;
-    background: linear-gradient(to right, #1d0b2f, #35134a);
-    color: white;
+    background-color: #ffffff;
+    color: #000000;
     text-align: center;
 }
 
@@ -54,7 +54,7 @@ body {
     margin: 0 1rem;
 }
 .dropdown-menu ul li a {
-    color: #fff;
+    color: #000;
     text-decoration: none;
     font-weight: bold;
 }
@@ -77,7 +77,7 @@ body {
 }
 #countdown {
     font-size: 2rem;
-    color: #fff;
+    color: #000;
     z-index: 1;
     position: relative;
 }


### PR DESCRIPTION
## Summary
- Replace gradient with white background and switch base text color to black
- Update dropdown menu links and countdown text for readability on white background

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6897bed9cf9083219e5b7dbc8b99660b