### PR TITLE
Ensure purple text and link favicons

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>Thrift Token - Redefining Circular Fashion</title>
     <link rel="stylesheet" href="styles.css"/>
+    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png"/>
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png"/>
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png"/>
+    <link rel="icon" type="image/png" sizes="192x192" href="android-chrome-192x192.png"/>
+    <link rel="icon" type="image/png" sizes="512x512" href="android-chrome-512x512.png"/>
+    <link rel="manifest" href="site.webmanifest"/>
+    <link rel="shortcut icon" href="favicon.ico"/>
     <script defer src="script.js"></script>
 </head>
 <body>

--- a/styles.css
+++ b/styles.css
@@ -23,7 +23,7 @@ body {
 .wallet-button {
     background-color: #c69cd9;
     border: none;
-    color: #fff;
+    color: #800080;
     padding: 10px 20px;
     margin: 1rem auto;
     font-size: 1rem;
@@ -137,7 +137,7 @@ footer {
     font-size: 1.2rem;
 }
 .footer-links a:hover {
-    color: #fff;
+    color: #800080;
 }
 
 /* Responsive */


### PR DESCRIPTION
## Summary
- Replace white text with purple for wallet button and footer hover to maintain visibility on white background.
- Add links to apple-touch-icon, favicons, Android icons, manifest, and shortcut icon for comprehensive favicon support.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897c38f16c88321b6ef641eee7ef5ad