### PR TITLE
Center roadmap, purple social icons, and new launch date

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,13 +6,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>Thrift Token - Redefining Circular Fashion</title>
     <link rel="stylesheet" href="styles.css"/>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"/>
     <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png"/>
     <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png"/>
     <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png"/>
     <link rel="icon" type="image/png" sizes="192x192" href="android-chrome-192x192.png"/>
     <link rel="icon" type="image/png" sizes="512x512" href="android-chrome-512x512.png"/>
     <link rel="manifest" href="site.webmanifest"/>
-    <link rel="shortcut icon" href="favicon.ico"/>
+    <link rel="icon" type="image/x-icon" href="favicon.ico"/>
     <script defer src="script.js"></script>
 </head>
 <body>
@@ -98,9 +99,9 @@
 
     <footer>
         <div class="footer-links">
-            <a href="https://twitter.com/thrift_token" target="_blank">Twitter</a>
-            <a href="https://t.me/thrifttoken" target="_blank">Telegram</a>
-            <a href="https://discord.com/invite/thrifttoken" target="_blank">Discord</a>
+            <a href="https://twitter.com/thrift_token" target="_blank" aria-label="Twitter"><i class="fab fa-twitter"></i></a>
+            <a href="https://t.me/thrifttoken" target="_blank" aria-label="Telegram"><i class="fab fa-telegram"></i></a>
+            <a href="https://discord.com/invite/thrifttoken" target="_blank" aria-label="Discord"><i class="fab fa-discord"></i></a>
         </div>
         <p>©ThriftToken | 2026</p>
     </footer>

--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 
 // Countdown Timer
 const countdown = document.getElementById("countdown");
-const launchDate = new Date("2025-12-01T00:00:00").getTime();
+const launchDate = new Date("2025-09-09T00:00:00").getTime();
 
 function updateCountdown() {
     const now = new Date().getTime();

--- a/styles.css
+++ b/styles.css
@@ -113,6 +113,17 @@ body {
     text-align: left;
     animation: pulse 2s ease infinite;
 }
+
+@media (min-width: 769px) {
+    .roadmap-container {
+        max-width: 800px;
+        margin-left: auto;
+        margin-right: auto;
+    }
+    .roadmap-phase {
+        text-align: center;
+    }
+}
 @keyframes fadeInUp {
     from { opacity: 0; transform: translateY(20px); }
     to { opacity: 1; transform: translateY(0); }
@@ -125,7 +136,7 @@ body {
 /* Footer */
 footer {
     background: #151515;
-    padding: 1rem;
+    padding: 1rem 1rem 2rem;
     color: #aaa;
 }
 .footer-links {
@@ -133,11 +144,11 @@ footer {
 }
 .footer-links a {
     margin: 0 1rem;
-    color: #c69cd9;
-    font-size: 1.2rem;
+    color: #800080;
+    font-size: 1.5rem;
 }
 .footer-links a:hover {
-    color: #800080;
+    color: #c69cd9;
 }
 
 /* Responsive */


### PR DESCRIPTION
## Summary
- center roadmap content on desktop with responsive CSS
- add purple font awesome social icons and extra footer padding
- correct favicon links and update countdown to 09/09/2025 00:00

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897c622db248321ab9c075749163403