### PR TITLE
Add instructional and feature icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,14 +41,20 @@
         <h2>How to Prepare</h2>
         <div class="steps">
             <div class="step">
+                <img src="https://raw.githubusercontent.com/MetaMask/brand-resources/master/SVG/metamask-fox.svg" alt="MetaMask logo" class="step-icon"/>
                 <h3>1. Install MetaMask</h3>
                 <p>Download MetaMask and set up your wallet.</p>
             </div>
             <div class="step">
+                <img src="https://cryptologos.cc/logos/polygon-matic-logo.svg?v=025" alt="Polygon logo" class="step-icon"/>
                 <h3>2. Switch to Polygon</h3>
                 <p>Add the Polygon network to your wallet settings.</p>
             </div>
             <div class="step">
+                <div class="step-icons">
+                    <img src="https://cryptologos.cc/logos/polygon-matic-logo.svg?v=025" alt="MATIC logo" class="step-icon"/>
+                    <img src="https://cryptologos.cc/logos/tether-usdt-logo.svg?v=025" alt="USDT logo" class="step-icon"/>
+                </div>
                 <h3>3. Fund Wallet</h3>
                 <p>Transfer MATIC or USDT tokens to your wallet address.</p>
             </div>
@@ -63,18 +69,22 @@
         <h2>Why Thrift Token?</h2>
         <div class="features-grid">
             <div class="feature-card">
+                <i class="fa-solid fa-globe feature-icon" aria-hidden="true"></i>
                 <h3>Web3 Ecosystem</h3>
                 <p>Built on Polygon for speed, scalability & low fees.</p>
             </div>
             <div class="feature-card">
+                <i class="fa-solid fa-hand-holding-heart feature-icon" aria-hidden="true"></i>
                 <h3>Transparent Donations</h3>
                 <p>Track clothing distribution and impact in real-time.</p>
             </div>
             <div class="feature-card">
+                <i class="fa-solid fa-recycle feature-icon" aria-hidden="true"></i>
                 <h3>Fiber Separation Tech</h3>
                 <p>Support textile recycling & responsible fashion.</p>
             </div>
             <div class="feature-card">
+                <i class="fa-solid fa-gavel feature-icon" aria-hidden="true"></i>
                 <h3>DAO Governance</h3>
                 <p>Community-led decisions with staking power.</p>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -98,6 +98,25 @@ body {
     border-radius: 10px;
     flex: 1 1 200px;
 }
+
+.step-icon {
+    width: 40px;
+    height: 40px;
+    margin-bottom: 0.5rem;
+}
+
+.step-icons {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.feature-icon {
+    font-size: 2rem;
+    color: #c69cd9;
+    margin-bottom: 0.5rem;
+}
 .roadmap-container {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- Display branded MetaMask, Polygon, MATIC and USDT icons alongside how-to steps
- Introduce Font Awesome visuals for feature cards
- Add styling for new step and feature icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897cd43448c8321b8a007940a32a2b9