### PR TITLE
feat: use local crypto logos

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,19 +41,19 @@
         <h2>How to Prepare</h2>
         <div class="steps">
             <div class="step">
-                <img src="https://raw.githubusercontent.com/MetaMask/brand-resources/master/SVG/metamask-fox.svg" alt="MetaMask logo" class="step-icon"/>
+                <img src="coins/MetaMask.png" alt="MetaMask logo" class="step-icon"/>
                 <h3>1. Install MetaMask</h3>
                 <p>Download MetaMask and set up your wallet.</p>
             </div>
             <div class="step">
-                <img src="https://cryptologos.cc/logos/polygon-matic-logo.svg?v=025" alt="Polygon logo" class="step-icon"/>
+                <img src="coins/polygon.png" alt="Polygon logo" class="step-icon"/>
                 <h3>2. Switch to Polygon</h3>
                 <p>Add the Polygon network to your wallet settings.</p>
             </div>
             <div class="step">
                 <div class="step-icons">
-                    <img src="https://cryptologos.cc/logos/polygon-matic-logo.svg?v=025" alt="MATIC logo" class="step-icon"/>
-                    <img src="https://cryptologos.cc/logos/tether-usdt-logo.svg?v=025" alt="USDT logo" class="step-icon"/>
+                    <img src="coins/matic.png" alt="MATIC logo" class="step-icon"/>
+                    <img src="coins/usdt.png" alt="USDT logo" class="step-icon"/>
                 </div>
                 <h3>3. Fund Wallet</h3>
                 <p>Transfer MATIC or USDT tokens to your wallet address.</p>


### PR DESCRIPTION
## Summary
- replace external MetaMask, Polygon, MATIC, and USDT icons with local PNG assets

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897d17320048321974ff8bde69708e8