### PR TITLE
Add animated Thrift coin to preparation steps

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
                 <p>Transfer MATIC or USDT tokens to your wallet address.</p>
             </div>
             <div class="step">
+                <img src="coins/thrift.png" alt="Thrift Token logo" class="step-icon thrift-coin"/>
                 <h3>4. Stay Tuned</h3>
                 <p>Thrift Token presale opens soon!</p>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -105,6 +105,20 @@ body {
     margin-bottom: 0.5rem;
 }
 
+.step-icon.thrift-coin {
+    animation: floatCoin 3s ease-in-out infinite, sparkleCoin 2s ease-in-out infinite;
+}
+
+@keyframes floatCoin {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-8px); }
+}
+
+@keyframes sparkleCoin {
+    0%, 100% { filter: drop-shadow(0 0 0px #c69cd9); }
+    50% { filter: drop-shadow(0 0 8px #c69cd9); }
+}
+
 .step-icons {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Summary
- Display Thrift coin icon for the fourth preparation step
- Animate the Thrift coin with floating and sparkling effects

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897e302e6f08321a30876cf1b58f4ea