### PR TITLE
feat: enlarge countdown and add language selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,10 @@
     <script defer src="script.js"></script>
 </head>
 <body>
+    <div class="language-container">
+        <button id="languageButton">Language</button>
+        <div id="google_translate_element" class="language-dropdown"></div>
+    </div>
     <header>
         <div class="logo">
             <img src="logo/thrifttoken.png" alt="Thrift Token Logo" />
@@ -212,5 +216,11 @@
         </div>
         <p>©ThriftToken | 2026</p>
     </footer>
+    <script>
+        function googleTranslateElementInit() {
+            new google.translate.TranslateElement({pageLanguage: 'en'}, 'google_translate_element');
+        }
+    </script>
+    <script src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -31,6 +31,8 @@ function toggleMenu() {
 // MetaMask Wallet Connection
 document.addEventListener("DOMContentLoaded", function () {
     const connectWalletBtn = document.getElementById("connectWallet");
+    const languageBtn = document.getElementById("languageButton");
+    const languageContainer = document.querySelector(".language-container");
 
     connectWalletBtn.addEventListener("click", async () => {
         if (typeof window.ethereum !== "undefined") {
@@ -44,4 +46,10 @@ document.addEventListener("DOMContentLoaded", function () {
             alert("Please install MetaMask to use this feature.");
         }
     });
+
+    if (languageBtn && languageContainer) {
+        languageBtn.addEventListener("click", () => {
+            languageContainer.classList.toggle("open");
+        });
+    }
 });

--- a/styles.css
+++ b/styles.css
@@ -80,6 +80,32 @@ section p::before {
     background-color: #b17cc7;
 }
 
+/* Language selector */
+.language-container {
+    position: fixed;
+    top: 10px;
+    left: 10px;
+    z-index: 1000;
+    text-align: left;
+}
+.language-container button {
+    background-color: #c69cd9;
+    border: 1px solid #000;
+    color: #ffffff;
+    padding: 5px 10px;
+    font-size: 0.9rem;
+    font-weight: bold;
+    border-radius: 5px;
+    cursor: pointer;
+}
+.language-dropdown {
+    display: none;
+    margin-top: 0.5rem;
+}
+.language-container.open .language-dropdown {
+    display: block;
+}
+
 /* Dropdown menu */
 .dropdown-arrow {
     font-size: 2rem;
@@ -126,7 +152,7 @@ section p::before {
     z-index: 0;
 }
 #countdown {
-    font-size: 2rem;
+    font-size: clamp(2.5rem, 8vw, 6rem);
     color: #000;
     z-index: 1;
     position: relative;
@@ -232,6 +258,13 @@ footer {
 }
 .footer-links a:hover {
     color: #c69cd9;
+}
+
+/* Tokenomics */
+#tokenomics .section-list {
+    text-align: center;
+    list-style-position: inside;
+    padding-left: 0;
 }
 
 /* Whitepaper button */


### PR DESCRIPTION
## Summary
- make countdown timer responsive and larger across devices
- center tokenomics details for consistent layout
- add Google Translate powered language selector with toggle

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/thrift-token/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689805a0e5808321920c8c11f64971c4