### PR TITLE
Bold countdown numbers and enlarge on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -17,7 +17,7 @@ function updateCountdown() {
     const mins = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
     const secs = Math.floor((distance % (1000 * 60)) / 1000);
 
-    countdown.innerHTML = `${days}d ${hrs}h ${mins}m ${secs}s`;
+    countdown.innerHTML = `<span class="count-num">${days}</span>d <span class="count-num">${hrs}</span>h <span class="count-num">${mins}</span>m <span class="count-num">${secs}</span>s`;
 }
 setInterval(updateCountdown, 1000);
 updateCountdown();

--- a/styles.css
+++ b/styles.css
@@ -158,6 +158,16 @@ section p::before {
     position: relative;
 }
 
+.count-num {
+    font-weight: bold;
+}
+
+@media (max-width: 600px) {
+    #countdown {
+        font-size: 4rem;
+    }
+}
+
 /* Features & Roadmap */
 .features-grid, .steps {
     display: flex;


### PR DESCRIPTION
## Summary
- Wrap countdown values in span elements and style them bold
- Increase countdown font size on mobile devices for better readability

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689807181c0083218a691db900926dfa