### PR TITLE
Compact countdown spacing for mobile view

### DIFF
--- a/script.js
+++ b/script.js
@@ -17,7 +17,7 @@ function updateCountdown() {
     const mins = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
     const secs = Math.floor((distance % (1000 * 60)) / 1000);
 
-    countdown.innerHTML = `<span class="count-num">${days}</span>d <span class="count-num">${hrs}</span>h <span class="count-num">${mins}</span>m <span class="count-num">${secs}</span>s`;
+    countdown.innerHTML = `<span class="count-num">${days}d</span><span class="count-num">${hrs}h</span><span class="count-num">${mins}m</span><span class="count-num">${secs}s</span>`;
 }
 setInterval(updateCountdown, 1000);
 updateCountdown();

--- a/styles.css
+++ b/styles.css
@@ -156,10 +156,16 @@ section p::before {
     color: #000;
     z-index: 1;
     position: relative;
+    white-space: nowrap;
 }
 
 .count-num {
     font-weight: bold;
+    margin-right: 0.3rem;
+}
+
+.count-num:last-child {
+    margin-right: 0;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- Prevent countdown from wrapping to a new line on mobile with `white-space: nowrap`
- Remove extra spaces and tighten spacing between countdown segments

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689809eb47cc83219a28f3f3241bbb8b