### PR TITLE
Style countdown timer with labels and lines

### DIFF
--- a/script.js
+++ b/script.js
@@ -17,7 +17,23 @@ function updateCountdown() {
     const mins = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
     const secs = Math.floor((distance % (1000 * 60)) / 1000);
 
-    countdown.innerHTML = `<span class="count-num">${days}d</span><span class="count-num">${hrs}h</span><span class="count-num">${mins}m</span><span class="count-num">${secs}s</span>`;
+    countdown.innerHTML = `
+        <div class="time-segment">
+            <span class="count-num">${days}</span>
+            <span class="count-label">Days</span>
+        </div>
+        <div class="time-segment">
+            <span class="count-num">${hrs}</span>
+            <span class="count-label">Hours</span>
+        </div>
+        <div class="time-segment">
+            <span class="count-num">${mins}</span>
+            <span class="count-label">Minutes</span>
+        </div>
+        <div class="time-segment">
+            <span class="count-num">${secs}</span>
+            <span class="count-label">Seconds</span>
+        </div>`;
 }
 setInterval(updateCountdown, 1000);
 updateCountdown();

--- a/styles.css
+++ b/styles.css
@@ -152,25 +152,41 @@ section p::before {
     z-index: 0;
 }
 #countdown {
-    font-size: clamp(2.5rem, 8vw, 6rem);
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    font-size: clamp(1.5rem, 4vw, 3rem);
     color: #000;
     z-index: 1;
     position: relative;
-    white-space: nowrap;
+}
+
+.time-segment {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0 0.5rem;
+    border-left: 1px solid #c69cd9;
+}
+
+.time-segment:first-child {
+    border-left: none;
 }
 
 .count-num {
     font-weight: bold;
-    margin-right: 0.3rem;
 }
 
-.count-num:last-child {
-    margin-right: 0;
+.count-label {
+    font-size: 0.6em;
+    margin-top: 0.2rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
 }
 
 @media (max-width: 600px) {
     #countdown {
-        font-size: 4rem;
+        font-size: 2rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- Resize countdown and restructure markup for labeled segments.
- Add flexbox styling with vertical separators and label formatting.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68980bc8e8408321ad0c9aa66607a0c6