### PR TITLE
Add tokenomics graph and utility animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,21 +171,40 @@
     <section id="tokenomics">
         <h2><i class="fa-solid fa-coins section-icon" aria-hidden="true"></i>Tokenomics</h2>
         <p>Total Supply: 1 billion tokens.</p>
-        <p>Allocation:</p>
-        <ul class="section-list">
-            <li>50% ICO and community rewards</li>
-            <li>20% Fiber separation R&amp;D</li>
-            <li>15% Marketing and partnerships</li>
-            <li>10% Team and advisors</li>
-            <li>5% Reserve fund</li>
-        </ul>
+        <h3>Allocation</h3>
+        <div class="allocation-graph">
+            <div class="allocation-bar" style="--percent:50; --bar-color:#ffcc00;">
+                <span>ICO &amp; Community Rewards - 50%</span>
+            </div>
+            <div class="allocation-bar" style="--percent:20; --bar-color:#ff66aa;">
+                <span>Fiber Separation R&amp;D - 20%</span>
+            </div>
+            <div class="allocation-bar" style="--percent:15; --bar-color:#66ccff;">
+                <span>Marketing &amp; Partnerships - 15%</span>
+            </div>
+            <div class="allocation-bar" style="--percent:10; --bar-color:#99e26b;">
+                <span>Team &amp; Advisors - 10%</span>
+            </div>
+            <div class="allocation-bar" style="--percent:5; --bar-color:#c69cd9;">
+                <span>Reserve Fund - 5%</span>
+            </div>
+        </div>
         <p>ICO Goal: $20 million to fund R&amp;D, dApp development, and hub infrastructure.</p>
-        <p>Token Utility:</p>
-        <ul class="section-list">
-            <li>Earn tokens by recycling garments.</li>
-            <li>Spend tokens on thrift items or recycling services.</li>
-            <li>Support redistribution efforts for underserved populations.</li>
-        </ul>
+        <h3>Token Utility</h3>
+        <div class="token-utility">
+            <div class="utility-item">
+                <i class="fa-solid fa-recycle utility-icon" aria-hidden="true"></i>
+                <p>Earn tokens by recycling garments.</p>
+            </div>
+            <div class="utility-item">
+                <i class="fa-solid fa-cart-shopping utility-icon" aria-hidden="true"></i>
+                <p>Spend tokens on thrift items or recycling services.</p>
+            </div>
+            <div class="utility-item">
+                <i class="fa-solid fa-hand-holding-heart utility-icon" aria-hidden="true"></i>
+                <p>Support redistribution efforts for underserved populations.</p>
+            </div>
+        </div>
     </section>
 
     <section id="roadmap">

--- a/styles.css
+++ b/styles.css
@@ -299,6 +299,75 @@ footer {
     padding-left: 0;
 }
 
+/* Tokenomics graph and utility */
+.allocation-graph {
+    max-width: 600px;
+    margin: 1.5rem auto;
+}
+
+.allocation-bar {
+    position: relative;
+    height: 40px;
+    margin: 0.5rem 0;
+    border: 4px solid #000;
+    border-radius: 10px;
+    background: #ffffff;
+    overflow: hidden;
+    box-shadow: 4px 4px 0 #000;
+}
+
+.allocation-bar::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 0;
+    background: var(--bar-color);
+    animation: growBar 1.5s ease-out forwards;
+}
+
+.allocation-bar span {
+    position: relative;
+    z-index: 1;
+    line-height: 40px;
+    font-weight: bold;
+}
+
+@keyframes growBar {
+    from { width: 0; }
+    to { width: calc(var(--percent) * 1%); }
+}
+
+.token-utility {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin: 1.5rem auto;
+    max-width: 600px;
+}
+
+.utility-item {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+}
+
+.utility-icon {
+    font-size: 2rem;
+    color: #c69cd9;
+    animation: bounce 2s ease-in-out infinite;
+}
+
+.utility-item:nth-child(2) .utility-icon { animation-delay: 0.3s; }
+.utility-item:nth-child(3) .utility-icon { animation-delay: 0.6s; }
+
+@keyframes bounce {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-10px); }
+}
+
 /* Whitepaper button */
 .whitepaper-container {
     text-align: center;


### PR DESCRIPTION
## Summary
- Replace textual tokenomics list with a cartoony allocation graph
- Add animated icons highlighting token utility actions

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68980e91726083219877f0281ed0c587