### PR TITLE
Revise supply to 92M and add cartoony tokenomics visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Web3 project revolutionizing circular fashion with blockchain and fiber innova
 Thrift Token tackles the 92 million tons of textile waste generated each year by combining advanced fiber separation technologies with a global secondhand marketplace. Built on Polygon for scalability and low fees, the project rewards users for recycling garments and redistributes clothing to underserved communities.
 
 ## Tokenomics
-- **Total Supply:** 1 billion tokens
+- **Total Supply:** 92,000,000 thrift tokens
 - **ICO Goal:** $20 million for R&D, dApp development, and network hubs
 - **Allocation:** 50% ICO & community rewards, 20% fiber separation R&D, 15% marketing & partnerships, 10% team & advisors, 5% reserve fund
 

--- a/ThriftToken.sol
+++ b/ThriftToken.sol
@@ -4,17 +4,17 @@ pragma solidity ^0.8.24;
 
 /// @title Thrift Token (THRIFT)
 /// @notice A purpose-driven ERC20 token launched to raise awareness and drive action around the global polyester landfill crisis.
-///         Each token represents a symbolic unit of the 90 million metric tons of unrecyclable polyester waste polluting landfills worldwide.
+///         Each token represents a symbolic unit of the 92 million metric tons of unrecyclable polyester waste polluting landfills worldwide.
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract ThriftToken is ERC20, Ownable {
-    /// @notice Total global polyester landfill waste (estimated) in metric tons = 90,000,000
-    ///         Minted supply is 90,000,000 tokens to reflect each ton of polyester waste
+    /// @notice Total global polyester landfill waste (estimated) in metric tons = 92,000,000
+    ///         Minted supply is 92,000,000 tokens to reflect each ton of polyester waste
     /// @dev Each token = 1 metric ton of landfill polyester waste for awareness and transparency
 
-    uint256 public constant INITIAL_SUPPLY = 90_000_000 * 10 ** 18; // 90 million tokens with 18 decimals
+    uint256 public constant INITIAL_SUPPLY = 92_000_000 * 10 ** 18; // 92 million tokens with 18 decimals
 
     constructor() ERC20("Thrift Token", "THRIFT") Ownable(msg.sender) {
         _mint(msg.sender, INITIAL_SUPPLY);

--- a/index.html
+++ b/index.html
@@ -122,27 +122,27 @@
         <h2><i class="fa-solid fa-mobile-screen section-icon" aria-hidden="true"></i>Thrift.Network dApp</h2>
         <div class="features-grid">
             <div class="feature-card">
-                <i class="fa-solid fa-infinity feature-icon" aria-hidden="true"></i>
+                <i class="fa-solid fa-infinity feature-icon cartoon" aria-hidden="true"></i>
                 <h3>Infinite Wardrobe</h3>
                 <p>Browse a virtual closet of thrift clothing filtered by size, style, and preference.</p>
             </div>
             <div class="feature-card">
-                <i class="fa-solid fa-arrows-rotate feature-icon" aria-hidden="true"></i>
+                <i class="fa-solid fa-arrows-rotate feature-icon cartoon" aria-hidden="true"></i>
                 <h3>Wardrobe Swaps</h3>
                 <p>Trade your old clothes for Thrift Tokens and refresh your look with secondhand finds.</p>
             </div>
             <div class="feature-card">
-                <i class="fa-solid fa-vr-cardboard feature-icon" aria-hidden="true"></i>
+                <i class="fa-solid fa-vr-cardboard feature-icon cartoon" aria-hidden="true"></i>
                 <h3>Augmented Reality Fitting</h3>
                 <p>Preview how garments will look using AR technology.</p>
             </div>
             <div class="feature-card">
-                <i class="fa-solid fa-gamepad feature-icon" aria-hidden="true"></i>
+                <i class="fa-solid fa-gamepad feature-icon cartoon" aria-hidden="true"></i>
                 <h3>Gamification</h3>
                 <p>Earn badges, rewards, and extra tokens for milestones like "10th Swap" or "100 Pounds Recycled."</p>
             </div>
             <div class="feature-card">
-                <i class="fa-solid fa-robot feature-icon" aria-hidden="true"></i>
+                <i class="fa-solid fa-robot feature-icon cartoon" aria-hidden="true"></i>
                 <h3>AI-Driven Suggestions</h3>
                 <p>Personalized recommendations based on your style and inventory trends.</p>
             </div>
@@ -151,26 +151,47 @@
 
     <section id="fiber-tech">
         <h2><i class="fa-solid fa-flask section-icon" aria-hidden="true"></i>Fiber Separation Technology</h2>
-        <ul class="section-list">
-            <li>Chemical recycling methods to safely separate synthetic and natural fibers.</li>
-            <li>Mechanical processes with advanced sorting for blended fabrics.</li>
-            <li>AI-powered assessment to identify optimal recycling paths for different textiles.</li>
-        </ul>
+        <div class="features-grid">
+            <div class="feature-card">
+                <i class="fa-solid fa-vial feature-icon cartoon" aria-hidden="true"></i>
+                <p>Chemical recycling methods to safely separate synthetic and natural fibers.</p>
+            </div>
+            <div class="feature-card">
+                <i class="fa-solid fa-gears feature-icon cartoon" aria-hidden="true"></i>
+                <p>Mechanical processes with advanced sorting for blended fabrics.</p>
+            </div>
+            <div class="feature-card">
+                <i class="fa-solid fa-brain feature-icon cartoon" aria-hidden="true"></i>
+                <p>AI-powered assessment to identify optimal recycling paths for different textiles.</p>
+            </div>
+        </div>
     </section>
 
     <section id="hubs">
         <h2><i class="fa-solid fa-store section-icon" aria-hidden="true"></i>Thrift Network Hubs</h2>
-        <ul class="section-list">
-            <li>Garment drop-off points where users receive Thrift Tokens for donations.</li>
-            <li>Recycling centers using cutting-edge fiber separation technology.</li>
-            <li>Redistribution hubs that clean and deliver garments to underserved populations.</li>
-            <li>Community engagement through educational workshops and sustainability events.</li>
-        </ul>
+        <div class="features-grid">
+            <div class="feature-card">
+                <i class="fa-solid fa-box-open feature-icon cartoon" aria-hidden="true"></i>
+                <p>Garment drop-off points where users receive Thrift Tokens for donations.</p>
+            </div>
+            <div class="feature-card">
+                <i class="fa-solid fa-recycle feature-icon cartoon" aria-hidden="true"></i>
+                <p>Recycling centers using cutting-edge fiber separation technology.</p>
+            </div>
+            <div class="feature-card">
+                <i class="fa-solid fa-truck feature-icon cartoon" aria-hidden="true"></i>
+                <p>Redistribution hubs that clean and deliver garments to underserved populations.</p>
+            </div>
+            <div class="feature-card">
+                <i class="fa-solid fa-people-group feature-icon cartoon" aria-hidden="true"></i>
+                <p>Community engagement through educational workshops and sustainability events.</p>
+            </div>
+        </div>
     </section>
 
     <section id="tokenomics">
         <h2><i class="fa-solid fa-coins section-icon" aria-hidden="true"></i>Tokenomics</h2>
-        <p>Total Supply: 1 billion tokens.</p>
+        <p><img src="coins/thrift.png" alt="Thrift Token" class="supply-icon"/>Total Supply: 92,000,000 thrift tokens.</p>
         <h3>Allocation</h3>
         <div class="allocation-graph">
             <div class="allocation-bar" style="--percent:50; --bar-color:#ffcc00;">

--- a/styles.css
+++ b/styles.css
@@ -238,6 +238,18 @@ section p::before {
     color: #c69cd9;
     margin-bottom: 0.5rem;
 }
+
+.feature-icon.cartoon {
+    animation: floatCoin 3s ease-in-out infinite, sparkleCoin 2s ease-in-out infinite;
+}
+
+.supply-icon {
+    width: 24px;
+    height: 24px;
+    margin-right: 0.3rem;
+    vertical-align: middle;
+    animation: floatCoin 3s ease-in-out infinite, sparkleCoin 2s ease-in-out infinite;
+}
 .roadmap-container {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- Align smart contract and docs with new 92,000,000 THRIFT supply
- Introduce animated cartoony icons for dApp, fiber-tech, and hub sections
- Show thrift.png coin beside token supply for playful tokenomics display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68981087d5748321b0e345f5332e33f1