### PR TITLE
Add vision board styling and animate icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
 
     <section id="vision">
         <h2><i class="fa-solid fa-eye section-icon" aria-hidden="true"></i>Vision &amp; Mission</h2>
-        <ul class="section-list">
+        <ul class="section-list vision-board">
             <li>Pioneer cutting-edge fiber separation technologies to recycle blended fabrics.</li>
             <li>Establish Thrift Network Hubs worldwide to facilitate recycling and redistribution.</li>
             <li>Build an infinite virtual wardrobe through the Thrift.Network dApp.</li>

--- a/styles.css
+++ b/styles.css
@@ -42,9 +42,52 @@ section p::before {
     color: #c69cd9;
 }
 
+.vision-board {
+    list-style: none;
+    padding-left: 0;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1rem;
+}
+
+.vision-board li {
+    background: #fff;
+    border: 2px solid #c69cd9;
+    box-shadow: 4px 4px 0 #000;
+    padding: 1rem;
+    width: 220px;
+    position: relative;
+    transform-origin: top center;
+    animation: swing 4s ease-in-out infinite;
+}
+
+.vision-board li::before {
+    content: '';
+    width: 15px;
+    height: 15px;
+    background: #c69cd9;
+    border: 2px solid #000;
+    border-radius: 50%;
+    position: absolute;
+    top: -10px;
+    left: 50%;
+    transform: translateX(-50%);
+}
+
+.vision-board li:nth-child(even) {
+    animation-delay: 2s;
+}
+
+@keyframes swing {
+    0%, 100% { transform: rotate(-2deg); }
+    50% { transform: rotate(2deg); }
+}
+
 .section-icon {
     color: #c69cd9;
     margin-right: 0.5rem;
+    animation: floatCoin 3s ease-in-out infinite, sparkleCoin 2s ease-in-out infinite;
 }
 
 @media (min-width: 769px) {
@@ -210,9 +253,6 @@ section p::before {
     width: 40px;
     height: 40px;
     margin-bottom: 0.5rem;
-}
-
-.step-icon.thrift-coin {
     animation: floatCoin 3s ease-in-out infinite, sparkleCoin 2s ease-in-out infinite;
 }
 
@@ -237,9 +277,6 @@ section p::before {
     font-size: 2rem;
     color: #c69cd9;
     margin-bottom: 0.5rem;
-}
-
-.feature-icon.cartoon {
     animation: floatCoin 3s ease-in-out infinite, sparkleCoin 2s ease-in-out infinite;
 }
 


### PR DESCRIPTION
## Summary
- Give Vision & Mission section a vision-board look with dangling paper notes
- Animate section, step, and feature icons with float and sparkle effects

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898128f24448321aa678f6763a1aaff