### PR TITLE
Switch graph order and highlight annual trajectory data

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,16 +62,18 @@
     <section id="mission">
         <h2><i class="fa-solid fa-bullseye section-icon" aria-hidden="true"></i>Mission</h2>
         <p>The global fashion industry produces over 92 million tons of textile waste annually, a number projected to grow by 60% by 2030. Thrift Token integrates advanced fiber separation technologies, blockchain transparency, and a gamified experience to build a circular textile economy that reduces waste and addresses clothing inequality.</p>
-        <h3><i class="fa-solid fa-chart-line section-icon" aria-hidden="true"></i>Unwanted Clothing Items</h3>
-        <div class="chart-container">
-            <canvas id="polyesterChart"></canvas>
-        </div>
-        <p class="graph-source">Source: <a href="https://example.com/polyester-landfill-data" target="_blank" rel="noopener">Global Polyester Landfill Data</a></p>
-        <h3><i class="fa-solid fa-chart-column section-icon" aria-hidden="true"></i>Landfill Fiber Comparison</h3>
+        <h3><i class="fa-solid fa-chart-column section-icon" aria-hidden="true"></i>Landfill Fiber Comparison (Annual Count)</h3>
+        <p>Annual landfill textile waste by material, used to project future trajectory.</p>
         <div class="chart-container">
             <canvas id="fiberComparisonChart"></canvas>
         </div>
         <p class="graph-source">Source: <a href="https://www.epa.gov/facts-and-figures-about-materials-waste-and-recycling/textiles-material-specific-data" target="_blank" rel="noopener">EPA Textile Waste Data</a></p>
+        <h3><i class="fa-solid fa-chart-line section-icon" aria-hidden="true"></i>Unwanted Clothing Items (Annual Count)</h3>
+        <p>Annual count of unwanted clothing items in thrifts, illustrating projected trajectory.</p>
+        <div class="chart-container">
+            <canvas id="polyesterChart"></canvas>
+        </div>
+        <p class="graph-source">Source: <a href="https://example.com/polyester-landfill-data" target="_blank" rel="noopener">Global Polyester Landfill Data</a></p>
     </section>
 
     <section id="how-to-buy">

--- a/script.js
+++ b/script.js
@@ -55,7 +55,7 @@ async function initPolyesterChart() {
             labels: [],
             datasets: [
                 {
-                    label: "Unwanted Clothing Items (millions)",
+                    label: "Unwanted Clothing Items (annual count, millions)",
                     data: [],
                     borderColor: "#c69cd9",
                     backgroundColor: "rgba(198,156,217,0.2)",
@@ -68,11 +68,11 @@ async function initPolyesterChart() {
             responsive: true,
             plugins: {
                 legend: { position: "top" },
-                title: { display: true, text: "Unwanted Clothing Items in Thrifts (Live)" }
+                title: { display: true, text: "Unwanted Clothing Items Trajectory (Annual Count)" }
             },
             scales: {
-                x: { title: { display: true, text: "Time" } },
-                y: { beginAtZero: true, title: { display: true, text: "Items (millions)" } }
+                x: { title: { display: true, text: "Year" } },
+                y: { beginAtZero: true, title: { display: true, text: "Items (millions per year)" } }
             }
         }
     });
@@ -87,10 +87,10 @@ async function initPolyesterChart() {
         }
     }
 
+    let year = new Date().getFullYear();
     async function updateChart() {
         const count = await fetchCount();
-        const now = new Date().toLocaleTimeString();
-        chart.data.labels.push(now);
+        chart.data.labels.push(year++);
         chart.data.datasets[0].data.push(count);
         if (chart.data.labels.length > 20) {
             chart.data.labels.shift();
@@ -124,7 +124,7 @@ async function initFiberComparisonChart() {
             labels: ["Polyester", "Cotton", "Denim", "Leather"],
             datasets: [
                 {
-                    label: "Landfill Waste (million tons)",
+                    label: "Annual Landfill Waste (million tons)",
                     data: [stats.polyester, stats.cotton, stats.denim, stats.leather],
                     backgroundColor: ["#c69cd9", "#ffcc00", "#66ccff", "#99e26b"],
                 },
@@ -134,10 +134,10 @@ async function initFiberComparisonChart() {
             responsive: true,
             plugins: {
                 legend: { display: false },
-                title: { display: true, text: "Landfill Textile Waste by Material (Live)" },
+                title: { display: true, text: "Annual Landfill Textile Waste by Material" },
             },
             scales: {
-                y: { beginAtZero: true, title: { display: true, text: "Million tons" } },
+                y: { beginAtZero: true, title: { display: true, text: "Million tons per year" } },
             },
         },
     });
@@ -225,6 +225,6 @@ document.addEventListener("DOMContentLoaded", function () {
         }
     });
 
-    initPolyesterChart();
     initFiberComparisonChart();
+    initPolyesterChart();
 });


### PR DESCRIPTION
## Summary
- Reorder mission section graphs so annual landfill comparison precedes unwanted clothing chart, with clear annual count descriptions.
- Emphasize annual counts and trajectory prediction in chart labels, titles, and axes.
- Drive polyester chart with yearly labels and update order of chart initialization.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689823136bf48321836a6354c10f94e7