### PR TITLE
Add tug-of-war animation comparing tokens to textile waste

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,14 @@
     <section id="mission">
         <h2><i class="fa-solid fa-bullseye section-icon" aria-hidden="true"></i>Mission</h2>
         <p>The global fashion industry produces over 92 million tons of textile waste annually, a number projected to grow by 60% by 2030. Thrift Token integrates advanced fiber separation technologies, blockchain transparency, and a gamified experience to build a circular textile economy that reduces waste and addresses clothing inequality.</p>
+        <div class="tug-of-war" id="tugOfWar">
+            <div id="tokenBar" class="tug-bar token"></div>
+            <div id="wasteBar" class="tug-bar waste"></div>
+        </div>
+        <div class="tug-labels">
+            <span id="tokenCount" class="token-label">0 Thrift Tokens</span>
+            <span id="wasteCount" class="waste-label">92,000,000,000 kg Waste</span>
+        </div>
         <h3><i class="fa-solid fa-chart-column section-icon" aria-hidden="true"></i>Landfill Fiber Comparison (Annual Count)</h3>
         <p>Annual landfill textile waste by material, used to project future trajectory.</p>
         <div class="chart-container">

--- a/script.js
+++ b/script.js
@@ -44,6 +44,38 @@ function toggleMenu() {
     menu.style.display = menu.style.display === "block" ? "none" : "block";
 }
 
+function initTugOfWar() {
+    const tokenBar = document.getElementById("tokenBar");
+    const wasteBar = document.getElementById("wasteBar");
+    const tokenCount = document.getElementById("tokenCount");
+    const wasteCount = document.getElementById("wasteCount");
+    if (!tokenBar || !wasteBar) return;
+
+    const maxTokens = 92_000_000;
+    const maxWaste = 92_000_000_000; // kg (92 million tons)
+    let tokens = 0;
+    let waste = maxWaste;
+
+    function step() {
+        tokens += maxTokens / 200;
+        waste -= maxWaste / 200;
+        if (tokens >= maxTokens && waste <= 0) {
+            tokens = 0;
+            waste = maxWaste;
+        }
+
+        const progress = ((tokens / maxTokens) + (1 - waste / maxWaste)) / 2;
+        tokenBar.style.width = progress * 100 + "%";
+        wasteBar.style.width = (1 - progress) * 100 + "%";
+
+        tokenCount.textContent = Math.round(tokens).toLocaleString() + " Thrift Tokens";
+        wasteCount.textContent = Math.round(waste).toLocaleString() + " kg Waste";
+    }
+
+    step();
+    setInterval(step, 100);
+}
+
 async function initPolyesterChart() {
     const canvas = document.getElementById("polyesterChart");
     if (!canvas) return;
@@ -227,4 +259,5 @@ document.addEventListener("DOMContentLoaded", function () {
 
     initFiberComparisonChart();
     initPolyesterChart();
+    initTugOfWar();
 });

--- a/styles.css
+++ b/styles.css
@@ -22,6 +22,43 @@ section p {
     line-height: 1.6;
 }
 
+/* Tug of War Graphic */
+.tug-of-war {
+    position: relative;
+    width: 100%;
+    height: 20px;
+    border: 2px solid #000;
+    margin: 1rem auto;
+    overflow: hidden;
+}
+.tug-bar {
+    position: absolute;
+    top: 0;
+    height: 100%;
+    transition: width 0.3s linear;
+}
+.tug-bar.token {
+    left: 0;
+    background-color: #800080;
+}
+.tug-bar.waste {
+    right: 0;
+    background-color: #ff0000;
+}
+.tug-labels {
+    display: flex;
+    justify-content: space-between;
+    max-width: 600px;
+    margin: 0.5rem auto 0;
+    font-size: 0.9rem;
+}
+.tug-labels .token-label {
+    color: #800080;
+}
+.tug-labels .waste-label {
+    color: #ff0000;
+}
+
 section p::before {
     font-family: "Font Awesome 6 Free";
     font-weight: 900;


### PR DESCRIPTION
## Summary
- Add animated tug-of-war bar under Mission illustrating 92M Thrift Tokens versus 92B kg of annual textile waste
- Style new bar and labels in purple and red to represent tokens and waste
- Implement JavaScript animation that continually increases token share while reducing waste

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68982671e61883218fc8eec7d9ae3dbd