### PR TITLE
Improve mission section spacing and graph subtitles

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,13 +70,13 @@
             <span id="tokenCount" class="token-label">0 Thrift Tokens</span>
             <span id="wasteCount" class="waste-label">92,000,000,000 kg Waste</span>
         </div>
-        <h3><i class="fa-solid fa-chart-column section-icon" aria-hidden="true"></i>Landfill Fiber Comparison (Annual Count)</h3>
+        <h3><i class="fa-solid fa-chart-column section-icon" aria-hidden="true"></i>Landfill Fiber Comparison <br><span class="annual-count">(Annual Count)</span></h3>
         <p>Annual landfill textile waste by material, used to project future trajectory.</p>
         <div class="chart-container">
             <canvas id="fiberComparisonChart"></canvas>
         </div>
         <p class="graph-source">Source: <a href="https://www.epa.gov/facts-and-figures-about-materials-waste-and-recycling/textiles-material-specific-data" target="_blank" rel="noopener">EPA Textile Waste Data</a></p>
-        <h3><i class="fa-solid fa-chart-line section-icon" aria-hidden="true"></i>Unwanted Clothing Items (Annual Count)</h3>
+        <h3><i class="fa-solid fa-chart-line section-icon" aria-hidden="true"></i>Unwanted Clothing Items <br><span class="annual-count">(Annual Count)</span></h3>
         <p>Annual count of unwanted clothing items in thrifts, illustrating projected trajectory.</p>
         <div class="chart-container">
             <canvas id="polyesterChart"></canvas>

--- a/styles.css
+++ b/styles.css
@@ -49,7 +49,7 @@ section p {
     display: flex;
     justify-content: space-between;
     max-width: 600px;
-    margin: 0.5rem auto 0;
+    margin: 0.5rem auto 2rem;
     font-size: 0.9rem;
 }
 .tug-labels .token-label {
@@ -57,6 +57,12 @@ section p {
 }
 .tug-labels .waste-label {
     color: #ff0000;
+}
+
+.annual-count {
+    display: block;
+    font-size: 0.8rem;
+    color: #008000;
 }
 
 section p::before {


### PR DESCRIPTION
## Summary
- add breathing room before the first graph in the mission section
- place graph subtitle "(Annual Count)" on its own green line for both charts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68982874a5248321a8f7730df3db3e51