### PR TITLE
Center header and reposition language and chat controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,21 +18,6 @@
     <script defer src="script.js"></script>
 </head>
 <body>
-    <div class="language-container">
-        <button id="languageButton">Language</button>
-        <div id="google_translate_element" class="language-dropdown"></div>
-        <button id="chatbotToggle" class="chatbot-toggle" aria-label="Open chat">
-            <i class="fa-solid fa-comments"></i>
-        </button>
-    </div>
-    <div id="chatbot" class="chatbot hidden">
-        <div class="chatbot-header">AI Assistant <span id="chatbotClose" class="chatbot-close">&times;</span></div>
-        <div id="chatbotMessages" class="chatbot-messages"></div>
-        <div class="chatbot-input">
-            <input type="text" id="chatbotInput" placeholder="Ask a question..."/>
-            <button id="chatbotSend">Send</button>
-        </div>
-    </div>
     <header>
         <div class="logo">
             <img src="logo/thrifttoken.png" alt="Thrift Token Logo" />
@@ -54,6 +39,21 @@
         </div>
         <button id="connectWallet" class="wallet-button">Connect Wallet</button>
     </header>
+    <div class="language-container">
+        <button id="languageButton">Language</button>
+        <div id="google_translate_element" class="language-dropdown"></div>
+        <button id="chatbotToggle" class="chatbot-toggle" aria-label="Open chat">
+            <i class="fa-solid fa-comments"></i>
+        </button>
+    </div>
+    <div id="chatbot" class="chatbot hidden">
+        <div class="chatbot-header">AI Assistant <span id="chatbotClose" class="chatbot-close">&times;</span></div>
+        <div id="chatbotMessages" class="chatbot-messages"></div>
+        <div class="chatbot-input">
+            <input type="text" id="chatbotInput" placeholder="Ask a question..."/>
+            <button id="chatbotSend">Send</button>
+        </div>
+    </div>
 
     <section id="hero">
         <div id="countdown" class="countdown"></div>

--- a/styles.css
+++ b/styles.css
@@ -10,7 +10,7 @@ body {
     background-color: #ffffff;
     color: #000000;
     text-align: center;
-    padding-top: 100px; /* Space for fixed header */
+    padding-top: 120px; /* Space for fixed header */
 }
 
 /* Fixed header so logo, menu arrow, and wallet button stay visible */
@@ -29,10 +29,27 @@ header {
 
 @media (max-width: 600px) {
     body {
-        padding-top: 90px;
+        padding-top: 120px;
     }
     .logo img {
         height: 50px;
+    }
+}
+
+@media (min-width: 769px) {
+    body {
+        padding-top: 200px;
+    }
+    header {
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+    }
+    .dropdown-arrow {
+        margin-top: 0.5rem;
+    }
+    #connectWallet {
+        margin-top: 0.5rem;
     }
 }
 
@@ -190,13 +207,14 @@ section p::before {
     background-color: #b17cc7;
 }
 
-/* Language selector */
+/* Language selector and chat toggle */
 .language-container {
-    position: fixed;
-    top: 10px;
-    left: 10px;
-    z-index: 1000;
-    text-align: left;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 1rem auto;
+    position: relative;
 }
 .language-container button {
     background-color: #c69cd9;
@@ -210,6 +228,9 @@ section p::before {
 }
 .language-dropdown {
     display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
     margin-top: 0.5rem;
 }
 .language-container.open .language-dropdown {
@@ -551,7 +572,6 @@ footer {
     border: 1px solid #000;
     color: #ffffff;
     padding: 5px;
-    margin-top: 0.5rem;
     border-radius: 50%;
     cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- Stack and center header contents on desktop for a cleaner layout
- Move language selector and chat toggle below the header to avoid overlap and align them horizontally

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68982e94f954832192b579eb9a470137