### PR TITLE
Use red for polyester and clothing waste graphs

### DIFF
--- a/script.js
+++ b/script.js
@@ -89,8 +89,8 @@ async function initPolyesterChart() {
                 {
                     label: "Unwanted Clothing Items (annual count, millions)",
                     data: [],
-                    borderColor: "#c69cd9",
-                    backgroundColor: "rgba(198,156,217,0.2)",
+                    borderColor: "#ff0000",
+                    backgroundColor: "rgba(255,0,0,0.2)",
                     borderWidth: 3,
                     tension: 0.4
                 }
@@ -158,7 +158,7 @@ async function initFiberComparisonChart() {
                 {
                     label: "Annual Landfill Waste (million tons)",
                     data: [stats.polyester, stats.cotton, stats.denim, stats.leather],
-                    backgroundColor: ["#c69cd9", "#ffcc00", "#66ccff", "#99e26b"],
+                    backgroundColor: ["#ff0000", "#ffcc00", "#66ccff", "#99e26b"],
                 },
             ],
         },

--- a/styles.css
+++ b/styles.css
@@ -542,7 +542,7 @@ footer {
     max-width: 600px;
     margin: 1rem auto;
     background: #fff;
-    border: 2px solid #c69cd9;
+    border: 2px solid #ff0000;
     box-shadow: 4px 4px 0 #000;
     padding: 1rem;
 }


### PR DESCRIPTION
## Summary
- Replace purple dataset colors in both graphs with red to represent polyester and unwanted clothing
- Switch chart container border color to red for consistent visual theme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898372b2a308321aba2238e30346eed