### PR TITLE
Align first graph colors with button palette

### DIFF
--- a/script.js
+++ b/script.js
@@ -89,8 +89,8 @@ async function initPolyesterChart() {
                 {
                     label: "Unwanted Clothing Items (annual count, millions)",
                     data: [],
-                    borderColor: "#ff0000",
-                    backgroundColor: "rgba(255,0,0,0.2)",
+                    borderColor: "#c69cd9",
+                    backgroundColor: "rgba(198,156,217,0.2)",
                     borderWidth: 3,
                     tension: 0.4
                 }
@@ -158,7 +158,9 @@ async function initFiberComparisonChart() {
                 {
                     label: "Annual Landfill Waste (million tons)",
                     data: [stats.polyester, stats.cotton, stats.denim, stats.leather],
-                    backgroundColor: ["#ff0000", "#ffcc00", "#66ccff", "#99e26b"],
+                    backgroundColor: ["#c69cd9", "#ffcc00", "#66ccff", "#99e26b"],
+                    borderColor: ["#c69cd9", "#ffcc00", "#66ccff", "#99e26b"],
+                    borderWidth: 1,
                 },
             ],
         },

--- a/styles.css
+++ b/styles.css
@@ -71,7 +71,7 @@ section p {
 }
 .tug-bar.token {
     left: 0;
-    background-color: #800080;
+    background-color: #c69cd9;
 }
 .tug-bar.waste {
     right: 0;
@@ -85,10 +85,10 @@ section p {
     font-size: 0.9rem;
 }
 .tug-labels .token-label {
-    color: #800080;
+    color: #c69cd9;
 }
 .tug-labels .waste-label {
-    color: #ff0000;
+    color: #c69cd9;
 }
 
 .annual-count {


### PR DESCRIPTION
## Summary
- Use the same light purple as the buttons for the first graph's data and outlines.
- Remove red accents from the graph, replacing them with the shared purple color.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689838cc07b083219a382a9cf6cf1281