### PR TITLE
Switch graph colors to red data and purple outlines

### DIFF
--- a/script.js
+++ b/script.js
@@ -89,8 +89,8 @@ async function initPolyesterChart() {
                 {
                     label: "Unwanted Clothing Items (annual count, millions)",
                     data: [],
-                    borderColor: "#c69cd9",
-                    backgroundColor: "rgba(198,156,217,0.2)",
+                    borderColor: "#ff0000",
+                    backgroundColor: "rgba(255,0,0,0.2)",
                     borderWidth: 3,
                     tension: 0.4
                 }
@@ -158,8 +158,8 @@ async function initFiberComparisonChart() {
                 {
                     label: "Annual Landfill Waste (million tons)",
                     data: [stats.polyester, stats.cotton, stats.denim, stats.leather],
-                    backgroundColor: ["#c69cd9", "#ffcc00", "#66ccff", "#99e26b"],
-                    borderColor: ["#c69cd9", "#ffcc00", "#66ccff", "#99e26b"],
+                    backgroundColor: ["#ff0000", "#ffcc00", "#66ccff", "#99e26b"],
+                    borderColor: ["#ff0000", "#ffcc00", "#66ccff", "#99e26b"],
                     borderWidth: 1,
                 },
             ],

--- a/styles.css
+++ b/styles.css
@@ -542,7 +542,7 @@ footer {
     max-width: 600px;
     margin: 1rem auto;
     background: #fff;
-    border: 2px solid #ff0000;
+    border: 2px solid #c69cd9;
     box-shadow: 4px 4px 0 #000;
     padding: 1rem;
 }


### PR DESCRIPTION
## Summary
- Use red instead of purple for fiber comparison and unwanted clothing charts
- Lighten chart container outlines to purple instead of red

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68983abde5588321a9b338aee6af6ea9