### PR TITLE
Improve roadmap visuals and navigation behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,9 @@
             <canvas id="polyesterChart"></canvas>
         </div>
         <p class="graph-source">Source: <a href="https://example.com/polyester-landfill-data" target="_blank" rel="noopener">Global Polyester Landfill Data</a></p>
+        <div class="whitepaper-container">
+            <a href="Thrift_Token_White_Paper_Version_1.1.pdf" class="whitepaper-button" target="_blank">Read Whitepaper</a>
+        </div>
     </section>
 
     <section id="how-to-buy">
@@ -275,10 +278,6 @@
         <h2><i class="fa-solid fa-bullhorn section-icon" aria-hidden="true"></i>Call to Action</h2>
         <p>Thrift Token is more than a cryptocurrency; it's a movement to revolutionize the fashion industry. Join our ICO, contribute to our open-source development, or partner with us to create a sustainable, circular textile economy. Together, we can transform waste into opportunity and make fashion truly sustainable.</p>
     </section>
-
-    <div class="whitepaper-container">
-        <a href="Thrift_Token_White_Paper_Version_1.1.pdf" class="whitepaper-button" target="_blank">Read Whitepaper</a>
-    </div>
 
     <footer>
         <div class="footer-links">

--- a/script.js
+++ b/script.js
@@ -259,6 +259,34 @@ document.addEventListener("DOMContentLoaded", function () {
         }
     });
 
+    const navLinks = document.querySelectorAll('#dropdown-menu a');
+    const sections = Array.from(navLinks).map(link => document.querySelector(link.getAttribute('href')));
+
+    function setActiveLink(link) {
+        navLinks.forEach(l => l.classList.remove('active'));
+        link.classList.add('active');
+    }
+
+    navLinks.forEach(link => {
+        link.addEventListener('click', () => setActiveLink(link));
+    });
+
+    function highlightOnScroll() {
+        const scrollPos = window.scrollY + window.innerHeight / 2;
+        const index = sections.findIndex(sec => sec.offsetTop <= scrollPos && (sec.offsetTop + sec.offsetHeight) > scrollPos);
+        if (index !== -1) {
+            setActiveLink(navLinks[index]);
+        }
+    }
+
+    window.addEventListener('scroll', () => {
+        if (document.getElementById('dropdown-menu').style.display === 'block') {
+            highlightOnScroll();
+        }
+    });
+
+    highlightOnScroll();
+
     const roadmapPhases = document.querySelectorAll(".roadmap-phase");
     const phaseObserver = new IntersectionObserver((entries) => {
         entries.forEach((entry) => {

--- a/styles.css
+++ b/styles.css
@@ -273,6 +273,9 @@ section p::before {
     text-decoration: none;
     font-weight: bold;
 }
+.dropdown-menu ul li a.active {
+    border-bottom: 2px solid #c69cd9;
+}
 .dropdown-menu ul li a:hover {
     color: #c69cd9;
 }
@@ -403,7 +406,7 @@ section p::before {
 }
 .roadmap-phase {
     position: relative;
-    background: rgba(255,255,255,0.07);
+    background: #ffffff;
     padding: 1rem 2rem;
     margin: 2rem 0;
     width: 80%;


### PR DESCRIPTION
## Summary
- Fill roadmap phase cards with white backgrounds to avoid timeline overlap
- Relocate whitepaper button to end of Mission section
- Highlight active navigation links in dropdown via light purple underline and scroll tracking

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689840d7071883219df86156bb6bd7ad