### PR TITLE
feat: recolor ICO chart and add tokenomics equation

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,6 +227,22 @@
     <section id="tokenomics">
         <h2><i class="fa-solid fa-coins section-icon" aria-hidden="true"></i>Tokenomics</h2>
         <p><img src="coins/thrift.png" alt="Thrift Token" class="supply-icon"/>Total Supply: 92,000,000 thrift tokens.</p>
+        <div class="token-equation">
+            <div class="eq-part">
+                <span class="eq-number">92,000,000,000</span>
+                <span class="eq-label">kg unwanted clothing</span>
+            </div>
+            <div class="eq-operator">÷</div>
+            <div class="eq-part">
+                <span class="eq-number">1,000</span>
+                <span class="eq-label">kg per token</span>
+            </div>
+            <div class="eq-operator">=</div>
+            <div class="eq-part">
+                <span class="eq-number">92,000,000</span>
+                <span class="eq-label">total tokens</span>
+            </div>
+        </div>
         <h3>Allocation</h3>
         <div class="allocation-graph">
             <div class="allocation-bar" style="--percent:50; --bar-color:#ffcc00;">

--- a/script.js
+++ b/script.js
@@ -204,7 +204,7 @@ async function initICOProgressChart() {
                     labels: ["Raised", "Remaining"],
                     datasets: [{
                         data: [raised, remaining],
-                        backgroundColor: ["#ff66aa", "#ffffff"],
+                        backgroundColor: ["#c69cd9", "#ffffff"],
                         borderColor: "#000",
                         borderWidth: 4,
                     }],

--- a/styles.css
+++ b/styles.css
@@ -587,7 +587,7 @@ footer {
 
 .ico-progress-wrapper {
     background: #e6f7ff;
-    border: 4px solid #ffcc00;
+    border: 4px solid #c69cd9;
     box-shadow: 6px 6px 0 #000;
     border-radius: 12px;
     padding: 2rem 1rem;
@@ -603,7 +603,7 @@ footer {
     align-items: center;
     gap: 0.5rem;
     font-size: 2rem;
-    color: #ffcc00;
+    color: #c69cd9;
     margin-bottom: 1rem;
 }
 
@@ -620,6 +620,50 @@ footer {
 .ico-goal-note {
     font-style: italic;
     margin-top: 0.5rem;
+}
+
+.token-equation {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: flex-end;
+    gap: 1rem;
+    margin: 2rem auto;
+    font-size: 1.2rem;
+}
+
+.eq-part {
+    background: #fff;
+    border: 2px solid #c69cd9;
+    box-shadow: 4px 4px 0 #000;
+    padding: 0.5rem 1rem;
+    border-radius: 8px;
+    text-align: center;
+    animation: popIn 0.6s ease forwards;
+}
+
+.eq-number {
+    color: #c69cd9;
+    font-size: 2rem;
+    font-weight: bold;
+    display: block;
+    animation: bounce 2s ease-in-out infinite;
+    filter: drop-shadow(2px 2px 0 #000);
+}
+
+.eq-label {
+    display: block;
+    font-size: 0.8rem;
+    color: #000;
+}
+
+.eq-operator {
+    font-size: 2rem;
+    font-weight: bold;
+    color: #c69cd9;
+    filter: drop-shadow(2px 2px 0 #000);
+    align-self: center;
+    animation: wiggle 2s ease-in-out infinite;
 }
 
 @keyframes bounce {


### PR DESCRIPTION
## Summary
- switch ICO progress chart styling to light purple
- add animated equation explaining 92M token supply

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898afc6fda88321b0504aa812b2f6e2