### PR TITLE
Improve tokenomics visuals and responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,11 +239,11 @@
             </div>
             <div class="eq-operator">=</div>
             <div class="eq-part">
-                <span class="eq-number">92,000,000</span>
+                <span class="eq-number">92,000,000<img src="coins/thrift.png" alt="Thrift Token" class="supply-icon"/></span>
                 <span class="eq-label">total tokens</span>
             </div>
         </div>
-        <h3 class="allocation-title"><img src="coins/thrift.png" alt="" class="allocation-icon"/>Allocation</h3>
+        <h3 class="allocation-title"><i class="fa-solid fa-chart-bar allocation-icon" aria-hidden="true"></i>Allocation</h3>
         <div class="allocation-graph">
             <div class="allocation-bar" style="--percent:50; --bar-color:#ffcc00;">
                 <span>ICO &amp; Community Rewards - 50%</span>

--- a/styles.css
+++ b/styles.css
@@ -407,6 +407,16 @@ section p::before {
     white-space: nowrap;
 }
 
+@media (max-width: 600px) {
+    .total-supply {
+        font-size: 1rem;
+        display: flex;
+        flex-wrap: wrap;
+        max-width: 100%;
+        white-space: normal;
+    }
+}
+
 .allocation-title {
     display: inline-flex;
     align-items: center;
@@ -414,8 +424,8 @@ section p::before {
 }
 
 .allocation-icon {
-    width: 24px;
-    height: 24px;
+    font-size: 1.5rem;
+    color: #c69cd9;
 }
 .roadmap-container {
     position: relative;


### PR DESCRIPTION
## Summary
- Shrink total supply line on small screens for better mobile display
- Show thrift token icon beside final equation total
- Swap allocation image for a bar chart font icon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b7a6805083218b0a21e56b2b957f