### PR TITLE
Fix home link highlight and style roadmap

### DIFF
--- a/script.js
+++ b/script.js
@@ -328,7 +328,7 @@ document.addEventListener("DOMContentLoaded", function () {
             const targetEl = document.getElementById(targetId);
             const headerOffset = document.querySelector('header').offsetHeight;
             const elementPos = targetEl.getBoundingClientRect().top + window.pageYOffset;
-            const offsetPos = elementPos - headerOffset;
+            const offsetPos = Math.max(elementPos - headerOffset, 0);
             window.scrollTo({ top: offsetPos, behavior: 'smooth' });
             setActiveLink(link);
             document.getElementById('dropdown-menu').style.display = 'none';
@@ -343,18 +343,17 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     function highlightOnScroll() {
-        const scrollPos = window.scrollY + window.innerHeight / 2;
-        const index = sections.findIndex(sec => sec.offsetTop <= scrollPos && (sec.offsetTop + sec.offsetHeight) > scrollPos);
+        const headerOffset = document.querySelector('header').offsetHeight;
+        const scrollPos = window.scrollY + headerOffset;
+        const index = sections.findIndex(sec => scrollPos >= sec.offsetTop && scrollPos < sec.offsetTop + sec.offsetHeight);
         if (index !== -1) {
             setActiveLink(navLinks[index]);
+        } else {
+            setActiveLink(navLinks[0]);
         }
     }
 
-    window.addEventListener('scroll', () => {
-        if (document.getElementById('dropdown-menu').style.display === 'block') {
-            highlightOnScroll();
-        }
-    });
+    window.addEventListener('scroll', highlightOnScroll);
 
     highlightOnScroll();
 

--- a/styles.css
+++ b/styles.css
@@ -462,6 +462,8 @@ section p::before {
     text-align: center;
     border: 2px solid #c69cd9;
     border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    font-weight: bold;
     opacity: 0;
     transform: translateY(20px);
     transition: opacity 0.6s ease-out, transform 0.6s ease-out;


### PR DESCRIPTION
## Summary
- Ensure Home nav link scrolls to top countdown and highlights on scroll.
- Add box shadows and bold text to roadmap phases for better emphasis.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898bdcd3c708321b655bea7da0dc2b7