### PR TITLE
style: add cartoony styling to remaining content

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -52,10 +52,18 @@ section {
     scroll-margin-top: 150px;
 }
 
-section p {
+section > p {
     max-width: 600px;
     margin: 1rem auto;
     line-height: 1.6;
+}
+
+section > p:not(.graph-source):not(.total-supply) {
+    font-weight: bold;
+    background: #fff;
+    border: 2px solid #c69cd9;
+    box-shadow: 4px 4px 0 #000;
+    padding: 0.5rem 1rem;
 }
 
 .cartoon {
@@ -105,7 +113,7 @@ section p {
     color: #008000;
 }
 
-section p::before {
+section > p:not(.graph-source):not(.total-supply)::before {
     font-family: "Font Awesome 6 Free";
     font-weight: 900;
     content: "\f105";
@@ -351,10 +359,13 @@ section p::before {
     max-width: 1000px;
 }
 .feature-card, .step {
-    background: rgba(255,255,255,0.05);
+    background: #fff;
     padding: 1rem;
+    border: 2px solid #c69cd9;
     border-radius: 10px;
+    box-shadow: 4px 4px 0 #000;
     flex: 1 1 200px;
+    font-weight: bold;
 }
 
 .step-icon {
@@ -462,7 +473,7 @@ section p::before {
     text-align: center;
     border: 2px solid #c69cd9;
     border-radius: 8px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    box-shadow: 4px 4px 0 #000;
     font-weight: bold;
     opacity: 0;
     transform: translateY(20px);


### PR DESCRIPTION
## Summary
- Add bold, shadowed box styling to top-level section text
- Give feature cards and prep steps a bordered, cartoon-style presentation
- Match roadmap phases with the same boxed cartoon aesthetic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898c12953f883218e41898e737b5f62