### PR TITLE
style: matrix green countdown box

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -317,9 +317,11 @@ section > p:not(.graph-source):not(.total-supply)::before {
     justify-content: center;
     gap: 0.5rem;
     font-size: clamp(1.5rem, 4vw, 3rem);
-    color: #000;
+    color: #00ff00;
     z-index: 1;
     position: relative;
+    background-color: #000;
+    padding: 0.5rem 1rem;
 }
 
 .time-segment {
@@ -327,7 +329,7 @@ section > p:not(.graph-source):not(.total-supply)::before {
     flex-direction: column;
     align-items: center;
     padding: 0 0.5rem;
-    border-left: 1px solid #c69cd9;
+    border-left: 1px solid #00ff00;
 }
 
 .time-segment:first-child {
@@ -336,6 +338,7 @@ section > p:not(.graph-source):not(.total-supply)::before {
 
 .count-num {
     font-weight: bold;
+    color: #00ff00;
 }
 
 .count-label {
@@ -343,6 +346,7 @@ section > p:not(.graph-source):not(.total-supply)::before {
     margin-top: 0.2rem;
     text-transform: uppercase;
     letter-spacing: 0.05em;
+    color: #00ff00;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- style countdown numbers, labels, and dividers in matrix green
- wrap countdown timer in black box

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898e6b12e1c8321bf4b1aeea4aff3b8