### PR TITLE
Limit countdown width to its content

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -322,6 +322,8 @@ section > p:not(.graph-source):not(.total-supply)::before {
     position: relative;
     background-color: #000;
     padding: 0.5rem 1rem;
+    width: fit-content;
+    margin: 0 auto;
 }
 
 .time-segment {


### PR DESCRIPTION
## Summary
- Keep countdown background from stretching by constraining its width to the text and centering it on the page

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6898e8d651ac8321b4b80da4b3b9dfc3