### PR TITLE
style: fix countdown size on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -353,7 +353,12 @@ section > p:not(.graph-source):not(.total-supply)::before {
 
 @media (max-width: 600px) {
     #countdown {
-        font-size: 2rem;
+        font-size: clamp(1rem, 6vw, 1.25rem);
+        gap: 0.25rem;
+    }
+
+    .time-segment {
+        padding: 0 0.25rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- scale countdown font and spacing for small screens to prevent overflow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898efead0fc8321bf8d67713b5c5605