### PR TITLE
Expand mobile countdown display

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -352,13 +352,18 @@ section > p:not(.graph-source):not(.total-supply)::before {
 }
 
 @media (max-width: 600px) {
+    #hero {
+        padding: 4rem 0;
+    }
+
     #countdown {
-        font-size: clamp(1rem, 6vw, 1.25rem);
-        gap: 0.25rem;
+        font-size: clamp(1.75rem, 10vw, 2.5rem);
+        gap: 0.5rem;
+        width: 100%;
     }
 
     .time-segment {
-        padding: 0 0.25rem;
+        padding: 0 0.5rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- Stretch countdown banner to full width on small screens and remove surrounding padding.
- Increase countdown font size and spacing on mobile for improved legibility.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898f36b22ac8321b92e23daea8f0f1b