### PR TITLE
Adjust countdown sizing for mobile view

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -357,13 +357,14 @@ section > p:not(.graph-source):not(.total-supply)::before {
     }
 
     #countdown {
-        font-size: clamp(1.75rem, 10vw, 2.5rem);
-        gap: 0.5rem;
+        font-size: clamp(1rem, 6vw, 1.5rem);
+        gap: 0.25rem;
         width: 100%;
+        padding: 0.25rem 0.5rem;
     }
 
     .time-segment {
-        padding: 0 0.5rem;
+        padding: 0 0.25rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- Reduce countdown font size and spacing on small screens for better mobile fit

## Testing
- `npm test` (fails: ENOENT: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6898f5d872e48321b1ce8d72078a1405