### PR TITLE
Adjust mobile countdown sizing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -357,10 +357,11 @@ section > p:not(.graph-source):not(.total-supply)::before {
     }
 
     #countdown {
-        font-size: clamp(1rem, 6vw, 1.5rem);
+        font-size: clamp(1.5rem, 8vw, 2.5rem);
         gap: 0.25rem;
-        width: 100%;
         padding: 0.25rem 0.5rem;
+        width: fit-content;
+        margin: 0 auto;
     }
 
     .time-segment {


### PR DESCRIPTION
## Summary
- enlarge countdown numbers on small screens
- limit mobile countdown container width to its contents

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898f778bb788321bf0ac913c1a3e3de