### PR TITLE
Move translation selector to top-left overlaying header

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -220,8 +220,8 @@ section > p:not(.graph-source):not(.total-supply)::before {
 /* Language selector and chat toggle */
 .language-container {
     position: fixed;
-    bottom: 20px;
-    left: 20px;
+    top: 0;
+    left: 0;
     right: auto;
     display: flex;
     flex-direction: column;
@@ -243,9 +243,9 @@ section > p:not(.graph-source):not(.total-supply)::before {
 .language-dropdown {
     display: none;
     position: absolute;
-    bottom: 100%;
+    top: 100%;
     left: 0;
-    margin-bottom: 0.5rem;
+    margin-top: 0.5rem;
 }
 .language-container.open .language-dropdown {
     display: block;


### PR DESCRIPTION
## Summary
- Keep the language selector pinned to the top-left corner of the viewport, even over the header
- Display Google Translate options below the selector button for better visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899060346f48321a79242f81ed69bd5