### PR TITLE
Add spacing around top-left language selector

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -220,8 +220,8 @@ section > p:not(.graph-source):not(.total-supply)::before {
 /* Language selector and chat toggle */
 .language-container {
     position: fixed;
-    top: 0;
-    left: 0;
+    top: 1rem;
+    left: 1rem;
     right: auto;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- keep language selector fixed in top-left with consistent spacing from edges across devices

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68990b01eefc8321a4dde81ab0c818d2