### PR TITLE
style: restore purple glow and green recycle icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,13 +73,13 @@
             <span id="tokenCount" class="token-label">0 Thrift Tokens</span>
             <span id="wasteCount" class="waste-label">92,000,000,000 kg Waste</span>
         </div>
-        <h3><i class="fa-solid fa-chart-column section-icon red-icon" aria-hidden="true"></i>Landfill Fiber Comparison <br><span class="annual-count">(Annual Count)</span></h3>
+        <h3><i class="fa-solid fa-chart-column section-icon" aria-hidden="true"></i>Landfill Fiber Comparison <br><span class="annual-count">(Annual Count)</span></h3>
         <p>Annual landfill textile waste by material, used to project future trajectory.</p>
         <div class="chart-container">
             <canvas id="fiberComparisonChart"></canvas>
         </div>
         <p class="graph-source">Source: <a href="https://www.epa.gov/facts-and-figures-about-materials-waste-and-recycling/textiles-material-specific-data" target="_blank" rel="noopener">EPA Textile Waste Data</a></p>
-        <h3><i class="fa-solid fa-chart-line section-icon red-icon" aria-hidden="true"></i>Unwanted Clothing Items <br><span class="annual-count">(Annual Count)</span></h3>
+        <h3><i class="fa-solid fa-chart-line section-icon" aria-hidden="true"></i>Unwanted Clothing Items <br><span class="annual-count">(Annual Count)</span></h3>
         <p>Annual count of unwanted clothing items in thrifts, illustrating projected trajectory.</p>
         <div class="chart-container">
             <canvas id="polyesterChart"></canvas>
@@ -117,7 +117,7 @@
     </section>
 
     <section id="features">
-        <h2><i class="fa-solid fa-star section-icon gold-icon" aria-hidden="true"></i>Why Thrift Token?</h2>
+        <h2><i class="fa-solid fa-star section-icon" aria-hidden="true"></i>Why Thrift Token?</h2>
         <div class="features-grid">
             <div class="feature-card">
                 <i class="fa-solid fa-globe feature-icon" aria-hidden="true"></i>
@@ -210,7 +210,7 @@
                 <p>Garment drop-off points where users receive Thrift Tokens for donations.</p>
             </div>
             <div class="feature-card">
-                <i class="fa-solid fa-recycle feature-icon green-icon" aria-hidden="true"></i>
+                <i class="fa-solid fa-recycle feature-icon cartoon green-icon" aria-hidden="true"></i>
                 <p>Recycling centers using cutting-edge fiber separation technology.</p>
             </div>
             <div class="feature-card">
@@ -263,7 +263,7 @@
         </div>
         <div class="token-graphs">
             <div class="token-utility-wrapper">
-                <h3 class="token-utility-title"><i class="fa-solid fa-star token-title-icon gold-icon" aria-hidden="true"></i>Token Utility</h3>
+                <h3 class="token-utility-title"><i class="fa-solid fa-star token-title-icon cartoon" aria-hidden="true"></i>Token Utility</h3>
                 <p class="tether-info">Each Thrift Token is tethered to the total count of unwanted clothing materials on planet Earth, transforming global waste into digital value.</p>
                 <div class="token-utility">
                     <div class="utility-item">

--- a/styles.css
+++ b/styles.css
@@ -183,18 +183,6 @@ section > p:not(.graph-source):not(.total-supply)::before {
     height: 1em;
 }
 
-.red-icon {
-    color: #ff0000;
-}
-
-.green-icon {
-    color: #28a745;
-}
-
-.gold-icon {
-    color: #ffd700;
-}
-
 @media (min-width: 769px) {
     section {
         max-width: 900px;
@@ -413,8 +401,8 @@ section > p:not(.graph-source):not(.total-supply)::before {
 }
 
 @keyframes sparkleCoin {
-    0%, 100% { filter: drop-shadow(0 0 0px currentColor); }
-    50% { filter: drop-shadow(0 0 8px currentColor); }
+    0%, 100% { filter: drop-shadow(0 0 0px #c69cd9); }
+    50% { filter: drop-shadow(0 0 8px #c69cd9); }
 }
 
 .step-icons {
@@ -633,7 +621,7 @@ footer {
 
 .token-title-icon {
     font-size: 2.5rem;
-    animation: wiggle 2s ease-in-out infinite, sparkleCoin 2s ease-in-out infinite;
+    animation: wiggle 2s ease-in-out infinite;
 }
 
 .tether-info {
@@ -668,11 +656,16 @@ footer {
 .utility-icon {
     font-size: 2rem;
     color: #c69cd9;
-    animation: bounce 2s ease-in-out infinite, sparkleCoin 2s ease-in-out infinite;
+    animation: bounce 2s ease-in-out infinite;
+    filter: drop-shadow(2px 2px 0 #000);
 }
 
 .utility-item:nth-child(2) .utility-icon { animation-delay: 0.3s; }
 .utility-item:nth-child(3) .utility-icon { animation-delay: 0.6s; }
+
+.green-icon {
+    color: #28a745;
+}
 
 .ico-progress-wrapper {
     background: #e6f7ff;


### PR DESCRIPTION
## Summary
- Revert sparkle animation to original purple glow for logo and coin imagery
- Add green icon helper class and apply to recycle icons
- Remove unintended color overrides from chart and star icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68991326a48c83219586d07f033d9fc7