### PR TITLE
style: add color cues for chart and star icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,13 +73,13 @@
             <span id="tokenCount" class="token-label">0 Thrift Tokens</span>
             <span id="wasteCount" class="waste-label">92,000,000,000 kg Waste</span>
         </div>
-        <h3><i class="fa-solid fa-chart-column section-icon" aria-hidden="true"></i>Landfill Fiber Comparison <br><span class="annual-count">(Annual Count)</span></h3>
+        <h3><i class="fa-solid fa-chart-column section-icon red-icon" aria-hidden="true"></i>Landfill Fiber Comparison <br><span class="annual-count">(Annual Count)</span></h3>
         <p>Annual landfill textile waste by material, used to project future trajectory.</p>
         <div class="chart-container">
             <canvas id="fiberComparisonChart"></canvas>
         </div>
         <p class="graph-source">Source: <a href="https://www.epa.gov/facts-and-figures-about-materials-waste-and-recycling/textiles-material-specific-data" target="_blank" rel="noopener">EPA Textile Waste Data</a></p>
-        <h3><i class="fa-solid fa-chart-line section-icon" aria-hidden="true"></i>Unwanted Clothing Items <br><span class="annual-count">(Annual Count)</span></h3>
+        <h3><i class="fa-solid fa-chart-line section-icon red-icon" aria-hidden="true"></i>Unwanted Clothing Items <br><span class="annual-count">(Annual Count)</span></h3>
         <p>Annual count of unwanted clothing items in thrifts, illustrating projected trajectory.</p>
         <div class="chart-container">
             <canvas id="polyesterChart"></canvas>
@@ -117,7 +117,7 @@
     </section>
 
     <section id="features">
-        <h2><i class="fa-solid fa-star section-icon" aria-hidden="true"></i>Why Thrift Token?</h2>
+        <h2><i class="fa-solid fa-star section-icon gold-icon" aria-hidden="true"></i>Why Thrift Token?</h2>
         <div class="features-grid">
             <div class="feature-card">
                 <i class="fa-solid fa-globe feature-icon" aria-hidden="true"></i>
@@ -263,7 +263,7 @@
         </div>
         <div class="token-graphs">
             <div class="token-utility-wrapper">
-                <h3 class="token-utility-title"><i class="fa-solid fa-star token-title-icon cartoon" aria-hidden="true"></i>Token Utility</h3>
+                <h3 class="token-utility-title"><i class="fa-solid fa-star token-title-icon cartoon gold-icon" aria-hidden="true"></i>Token Utility</h3>
                 <p class="tether-info">Each Thrift Token is tethered to the total count of unwanted clothing materials on planet Earth, transforming global waste into digital value.</p>
                 <div class="token-utility">
                     <div class="utility-item">

--- a/styles.css
+++ b/styles.css
@@ -183,6 +183,21 @@ section > p:not(.graph-source):not(.total-supply)::before {
     height: 1em;
 }
 
+.section-icon.red-icon {
+    color: #ff0000;
+    animation: floatCoin 3s ease-in-out infinite, sparkleRed 2s ease-in-out infinite;
+}
+
+.section-icon.gold-icon {
+    color: #FFD700;
+    animation: floatCoin 3s ease-in-out infinite, sparkleGold 2s ease-in-out infinite;
+}
+
+.token-title-icon.gold-icon {
+    color: #FFD700;
+    animation: wiggle 2s ease-in-out infinite, sparkleGold 2s ease-in-out infinite;
+}
+
 @media (min-width: 769px) {
     section {
         max-width: 900px;
@@ -403,6 +418,16 @@ section > p:not(.graph-source):not(.total-supply)::before {
 @keyframes sparkleCoin {
     0%, 100% { filter: drop-shadow(0 0 0px #c69cd9); }
     50% { filter: drop-shadow(0 0 8px #c69cd9); }
+}
+
+@keyframes sparkleRed {
+    0%, 100% { filter: drop-shadow(0 0 0px #ff0000); }
+    50% { filter: drop-shadow(0 0 8px #ff0000); }
+}
+
+@keyframes sparkleGold {
+    0%, 100% { filter: drop-shadow(0 0 0px #FFD700); }
+    50% { filter: drop-shadow(0 0 8px #FFD700); }
 }
 
 .step-icons {


### PR DESCRIPTION
## Summary
- make landfill fiber and unwanted clothing chart icons red with matching glow
- color star icons gold with synchronized glow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899162bb1f88321aad91994cc528367