### PR TITLE
style: add hot pink icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
                 <p>Built on Polygon for speed, scalability & low fees.</p>
             </div>
             <div class="feature-card">
-                <i class="fa-solid fa-hand-holding-heart feature-icon" aria-hidden="true"></i>
+                <i class="fa-solid fa-hand-holding-heart feature-icon pink-icon" aria-hidden="true"></i>
                 <h3>Transparent Donations</h3>
                 <p>Track clothing distribution and impact in real-time.</p>
             </div>
@@ -196,7 +196,7 @@
                 <p>Mechanical processes with advanced sorting for blended fabrics.</p>
             </div>
             <div class="feature-card">
-                <i class="fa-solid fa-brain feature-icon cartoon" aria-hidden="true"></i>
+                <i class="fa-solid fa-brain feature-icon cartoon pink-icon" aria-hidden="true"></i>
                 <p>AI-powered assessment to identify optimal recycling paths for different textiles.</p>
             </div>
         </div>
@@ -275,7 +275,7 @@
                         <p>Spend tokens on thrift items or recycling services.</p>
                     </div>
                     <div class="utility-item">
-                        <i class="fa-solid fa-hand-holding-heart utility-icon" aria-hidden="true"></i>
+                        <i class="fa-solid fa-hand-holding-heart utility-icon pink-icon sparkle-icon" aria-hidden="true"></i>
                         <p>Support redistribution efforts for underserved populations.</p>
                     </div>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -416,8 +416,8 @@ section > p:not(.graph-source):not(.total-supply)::before {
 }
 
 @keyframes sparkleCoin {
-    0%, 100% { filter: drop-shadow(0 0 0px #c69cd9); }
-    50% { filter: drop-shadow(0 0 8px #c69cd9); }
+    0%, 100% { filter: drop-shadow(0 0 0px currentColor); }
+    50% { filter: drop-shadow(0 0 8px currentColor); }
 }
 
 @keyframes sparkleRed {
@@ -687,6 +687,14 @@ footer {
 
 .utility-item:nth-child(2) .utility-icon { animation-delay: 0.3s; }
 .utility-item:nth-child(3) .utility-icon { animation-delay: 0.6s; }
+
+.pink-icon {
+    color: #ff66aa;
+}
+
+.sparkle-icon {
+    animation: bounce 2s ease-in-out infinite, sparkleCoin 2s ease-in-out infinite;
+}
 
 .green-icon {
     color: #28a745;


### PR DESCRIPTION
## Summary
- add pink icon style and sparkle animation to match Fiber Separation R&D color
- highlight Transparent Donations, AI-powered assessment, and redistribution utility icons in hot pink
- generalize sparkle animation to follow icon color for consistent glow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689918c74fe48321a4b6e3213d99750a