### PR TITLE
Restore purple glow and adjust feature icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
                 <p>Browse a virtual closet of thrift clothing filtered by size, style, and preference.</p>
             </div>
             <div class="feature-card">
-                <i class="fa-solid fa-arrows-rotate feature-icon cartoon" aria-hidden="true"></i>
+                <i class="fa-solid fa-arrows-rotate feature-icon cartoon green-icon" aria-hidden="true"></i>
                 <h3>Wardrobe Swaps</h3>
                 <p>Trade your old clothes for Thrift Tokens and refresh your look with secondhand finds.</p>
             </div>
@@ -188,7 +188,7 @@
         <h2><i class="fa-solid fa-flask section-icon" aria-hidden="true"></i>Fiber Separation Technology</h2>
         <div class="features-grid">
             <div class="feature-card">
-                <i class="fa-solid fa-vial feature-icon cartoon" aria-hidden="true"></i>
+                <i class="fa-solid fa-vial feature-icon cartoon green-icon" aria-hidden="true"></i>
                 <p>Chemical recycling methods to safely separate synthetic and natural fibers.</p>
             </div>
             <div class="feature-card">

--- a/styles.css
+++ b/styles.css
@@ -212,6 +212,7 @@ section > p:not(.graph-source):not(.total-supply)::before {
     height: 60px;
     margin: 0;
     display: block;
+    color: #c69cd9;
     animation: floatCoin 3s ease-in-out infinite, sparkleCoin 2s ease-in-out infinite;
 }
 
@@ -449,7 +450,12 @@ section > p:not(.graph-source):not(.total-supply)::before {
     height: 24px;
     margin-left: 0.3rem;
     vertical-align: middle;
+    color: #c69cd9;
     animation: floatCoin 3s ease-in-out infinite, sparkleCoin 2s ease-in-out infinite;
+}
+
+.thrift-coin {
+    color: #c69cd9;
 }
 
 .total-supply {


### PR DESCRIPTION
## Summary
- Bring back light purple glow for the header logo and thrift token coin images
- Color Wardrobe Swaps and chemical recycling feature icons green

## Testing
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68991b469dbc8321af35a7626c77c197