### PR TITLE
style: add metallic blue glow to feature icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
         <h2><i class="fa-solid fa-star section-icon gold-icon" aria-hidden="true"></i>Why Thrift Token?</h2>
         <div class="features-grid">
             <div class="feature-card">
-                <i class="fa-solid fa-globe feature-icon" aria-hidden="true"></i>
+                <i class="fa-solid fa-globe feature-icon blue-glow-icon" aria-hidden="true"></i>
                 <h3>Web3 Ecosystem</h3>
                 <p>Built on Polygon for speed, scalability & low fees.</p>
             </div>
@@ -167,7 +167,7 @@
                 <p>Trade your old clothes for Thrift Tokens and refresh your look with secondhand finds.</p>
             </div>
             <div class="feature-card">
-                <i class="fa-solid fa-vr-cardboard feature-icon cartoon" aria-hidden="true"></i>
+                <i class="fa-solid fa-vr-cardboard feature-icon cartoon blue-glow-icon" aria-hidden="true"></i>
                 <h3>Augmented Reality Fitting</h3>
                 <p>Preview how garments will look using AR technology.</p>
             </div>
@@ -177,7 +177,7 @@
                 <p>Earn badges, rewards, and extra tokens for milestones like "10th Swap" or "100 Pounds Recycled."</p>
             </div>
             <div class="feature-card">
-                <i class="fa-solid fa-robot feature-icon cartoon" aria-hidden="true"></i>
+                <i class="fa-solid fa-robot feature-icon cartoon blue-glow-icon" aria-hidden="true"></i>
                 <h3>AI-Driven Suggestions</h3>
                 <p>Personalized recommendations based on your style and inventory trends.</p>
             </div>
@@ -192,7 +192,7 @@
                 <p>Chemical recycling methods to safely separate synthetic and natural fibers.</p>
             </div>
             <div class="feature-card">
-                <i class="fa-solid fa-gears feature-icon cartoon" aria-hidden="true"></i>
+                <i class="fa-solid fa-gears feature-icon cartoon blue-glow-icon" aria-hidden="true"></i>
                 <p>Mechanical processes with advanced sorting for blended fabrics.</p>
             </div>
             <div class="feature-card">
@@ -218,7 +218,7 @@
                 <p>Redistribution hubs that clean and deliver garments to underserved populations.</p>
             </div>
             <div class="feature-card">
-                <i class="fa-solid fa-people-group feature-icon cartoon" aria-hidden="true"></i>
+                <i class="fa-solid fa-people-group feature-icon cartoon blue-glow-icon" aria-hidden="true"></i>
                 <p>Community engagement through educational workshops and sustainability events.</p>
             </div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -706,6 +706,11 @@ footer {
     color: #28a745;
 }
 
+.blue-glow-icon {
+    color: #1e90ff;
+    text-shadow: 0 0 5px #1e90ff, 0 0 10px #1e90ff;
+}
+
 .ico-progress-wrapper {
     background: #e6f7ff;
     border: 4px solid #c69cd9;


### PR DESCRIPTION
## Summary
- add reusable `blue-glow-icon` class for metallic blue glow styling
- apply metallic blue glow to icons for Web3 ecosystem, AR fitting, AI suggestions, mechanical sorting, and community engagement

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68991de26c3c8321a74d0a5c55c31446