### PR TITLE
Refine tokenomics icons and blue glow styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,7 +225,7 @@
     </section>
 
     <section id="tokenomics">
-        <h2><i class="fa-solid fa-coins section-icon" aria-hidden="true"></i>Tokenomics</h2>
+        <h2><i class="fa-solid fa-coins section-icon gold-icon" aria-hidden="true"></i>Tokenomics</h2>
         <p class="total-supply"><span>Total Supply: 92,000,000 thrift tokens.</span><img src="coins/thrift.png" alt="Thrift Token" class="supply-icon"/></p>
         <div class="token-equation">
             <div class="eq-part">
@@ -243,7 +243,7 @@
                 <span class="eq-label">total tokens</span>
             </div>
         </div>
-        <h3 class="allocation-title"><i class="fa-solid fa-chart-bar allocation-icon" aria-hidden="true"></i>Allocation</h3>
+        <h3 class="allocation-title"><img src="coins/thrift.png" alt="Allocation icon" class="allocation-icon"/>Allocation</h3>
         <div class="allocation-graph">
             <div class="allocation-bar" style="--percent:50; --bar-color:#ffcc00;">
                 <span>ICO &amp; Community Rewards - 50%</span>

--- a/styles.css
+++ b/styles.css
@@ -491,7 +491,8 @@ section > p:not(.graph-source):not(.total-supply)::before {
 }
 
 .allocation-icon {
-    font-size: 1.5rem;
+    width: 1.5rem;
+    height: 1.5rem;
     color: #c69cd9;
     margin-right: 0.5rem;
     animation: floatCoin 3s ease-in-out infinite, sparkleCoin 2s ease-in-out infinite;
@@ -708,7 +709,6 @@ footer {
 
 .blue-glow-icon {
     color: #1e90ff;
-    text-shadow: 0 0 5px #1e90ff, 0 0 10px #1e90ff;
 }
 
 .ico-progress-wrapper {


### PR DESCRIPTION
## Summary
- tone down metallic blue glow on feature icons
- color Tokenomics section title icon gold to match stars
- use thrift.png for Allocation icon with consistent sizing

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68991ffbdc5c832192038f8108ada998