### PR TITLE
Add animated coin overlay to mission textile image

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,10 @@
 
     <section id="mission">
         <h2><img src="earth.png" alt="Mission icon" class="section-icon"/>Mission</h2>
+        <div class="mission-image">
+            <img src="textilepile.png" alt="Pile of textiles"/>
+            <div class="coin-overlay"></div>
+        </div>
         <p>The global fashion industry produces over 92 million tons of textile waste annually, a number projected to grow by 60% by 2030. Thrift Token integrates advanced fiber separation technologies, blockchain transparency, and a gamified experience to build a circular textile economy that reduces waste and addresses clothing inequality.</p>
         <div class="whitepaper-container">
             <a href="Thrift_Token_White_Paper_Version_1.1.pdf" class="whitepaper-button" target="_blank">Read Whitepaper</a>

--- a/styles.css
+++ b/styles.css
@@ -113,6 +113,35 @@ section > p:not(.graph-source):not(.total-supply) {
     color: #008000;
 }
 
+.mission-image {
+    position: relative;
+    max-width: 300px;
+    margin: 1rem auto;
+}
+
+.mission-image img {
+    width: 100%;
+    display: block;
+}
+
+.coin-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-image: url('coins/thrift.png');
+    background-size: 50px 50px;
+    background-repeat: repeat;
+    clip-path: inset(0 0 100% 0);
+    animation: coinCover 5s linear infinite;
+}
+
+@keyframes coinCover {
+    0% { clip-path: inset(0 0 100% 0); }
+    100% { clip-path: inset(0 0 0 0); }
+}
+
 section > p:not(.graph-source):not(.total-supply)::before {
     font-family: "Font Awesome 6 Free";
     font-weight: 900;


### PR DESCRIPTION
## Summary
- Center a textile pile image beneath the Mission heading.
- Overlay repeating Thrift coin graphics that progressively cover the image via CSS animation.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689923fd88848321be4d5ee9d29811ec