### PR TITLE
Fix coin rain animation visibility

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -119,24 +119,27 @@ section > p:not(.graph-source):not(.total-supply) {
     margin: 1rem auto;
 }
 
+/* Ensure the pile of clothes image forms the base layer */
 .mission-image img {
     width: 100%;
     display: block;
-    position: relative;
-    z-index: 0;
 }
 
 .coin-container {
     position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+    inset: 0; /* shorthand for top/right/bottom/left 0 */
     pointer-events: none;
     overflow: hidden;
-    -webkit-mask: url('textilepile.png') no-repeat center/100% 100%;
-    mask: url('textilepile.png') no-repeat center/100% 100%;
-    z-index: 1;
+    /* Explicit mask properties for better browser support */
+    -webkit-mask-image: url('textilepile.png');
+    -webkit-mask-repeat: no-repeat;
+    -webkit-mask-size: 100% 100%;
+    -webkit-mask-position: center;
+    mask-image: url('textilepile.png');
+    mask-repeat: no-repeat;
+    mask-size: 100% 100%;
+    mask-position: center;
+    z-index: 10; /* place coins above the image */
 }
 
 .coin {
@@ -148,7 +151,7 @@ section > p:not(.graph-source):not(.total-supply) {
     background-size: contain;
     background-repeat: no-repeat;
     animation: coinFall 3s linear forwards;
-    z-index: 2;
+    z-index: 11;
 }
 
 @keyframes coinFall {


### PR DESCRIPTION
## Summary
- Ensure pile-of-clothes image acts as base layer for mission section
- Overlay coin rain above image using explicit mask properties and higher z-index values

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/thrift-token/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68992a98710c8321894ad4edb9a5628e