### PR TITLE
Reduce coin rain density for clearer animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -241,7 +241,8 @@ function initCoinRain() {
         coin.addEventListener('animationend', () => coin.remove());
     }
 
-    setInterval(spawnCoin, 80);
+    // Drop fewer coins so the effect is visible without overwhelming the page
+    setInterval(spawnCoin, 300);
 }
 
 // MetaMask Wallet Connection

--- a/styles.css
+++ b/styles.css
@@ -135,23 +135,14 @@ section > p:not(.graph-source):not(.total-supply) {
     height: 100%;
     pointer-events: none;
     overflow: hidden;
-    /* Explicit mask properties for better browser support */
-    -webkit-mask-image: url('textilepile.png');
-    -webkit-mask-repeat: no-repeat;
-    -webkit-mask-size: 100% 100%;
-    -webkit-mask-position: center;
-    mask-image: url('textilepile.png');
-    mask-repeat: no-repeat;
-    mask-size: 100% 100%;
-    mask-position: center;
     z-index: 10; /* place coins above the image */
 }
 
 .coin {
     position: absolute;
     top: -10%;
-    width: 25px;
-    height: 25px;
+    width: 35px;
+    height: 35px;
     background-image: url('coins/thrift.png');
     background-size: contain;
     background-repeat: no-repeat;


### PR DESCRIPTION
## Summary
- remove masking on coin rain container and enlarge coins so they are visible
- slow coin spawning to lighten animation load

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/thrift-token/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68993043ebc8832181e5b5f40326ce6b