### PR TITLE
Restrict coin rain to triangular textile pile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -136,6 +136,8 @@ section > p:not(.graph-source):not(.total-supply) {
     pointer-events: none;
     overflow: hidden;
     z-index: 10; /* place coins above the image */
+    clip-path: polygon(50% 0, 0 100%, 100% 100%);
+    -webkit-clip-path: polygon(50% 0, 0 100%, 100% 100%);
 }
 
 .coin {


### PR DESCRIPTION
## Summary
- Trimmed coin overlay to a triangular clip-path that matches the textile pile

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689931f648f883219bcd72137f9e5bf1