### PR TITLE
Increase coin rain coverage and density

### DIFF
--- a/script.js
+++ b/script.js
@@ -241,8 +241,8 @@ function initCoinRain() {
         coin.addEventListener('animationend', () => coin.remove());
     }
 
-    // Drop fewer coins so the effect is visible without overwhelming the page
-    setInterval(spawnCoin, 300);
+    // Drop more coins for a denser effect
+    setInterval(spawnCoin, 100);
 }
 
 // MetaMask Wallet Connection

--- a/styles.css
+++ b/styles.css
@@ -136,13 +136,10 @@ section > p:not(.graph-source):not(.total-supply) {
     pointer-events: none;
     overflow: hidden;
     z-index: 10; /* place coins above the image */
-    clip-path: polygon(50% 0, 0 100%, 100% 100%);
-    -webkit-clip-path: polygon(50% 0, 0 100%, 100% 100%);
 }
 
 .coin {
     position: absolute;
-    top: -10%;
     width: 35px;
     height: 35px;
     background-image: url('coins/thrift.png');
@@ -153,8 +150,8 @@ section > p:not(.graph-source):not(.total-supply) {
 }
 
 @keyframes coinFall {
-    0% { transform: translateY(0); }
-    100% { transform: translateY(120%); }
+    0% { top: -10%; }
+    100% { top: 110%; }
 }
 
 section > p:not(.graph-source):not(.total-supply)::before {


### PR DESCRIPTION
## Summary
- Remove clipping from coin container so rain spans entire mission image
- Adjust coin fall animation to travel full height and exit at bottom
- Increase coin spawn rate for denser coverage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899337b6ee88321b1b5ecb6ad34992f