### PR TITLE
Align coin rain with mountain image

### DIFF
--- a/script.js
+++ b/script.js
@@ -232,17 +232,43 @@ async function initICOProgressChart() {
 function initCoinRain() {
     const container = document.querySelector('.coin-container');
     if (!container) return;
+    const maskImg = new Image();
+    maskImg.src = 'textilepile.png';
+    maskImg.onload = () => {
+        const canvas = document.createElement('canvas');
+        canvas.width = maskImg.width;
+        canvas.height = maskImg.height;
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(maskImg, 0, 0);
+        const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
 
-    function spawnCoin() {
-        const coin = document.createElement('div');
-        coin.className = 'coin';
-        coin.style.left = Math.random() * 100 + '%';
-        container.appendChild(coin);
-        coin.addEventListener('animationend', () => coin.remove());
-    }
+        function getTopOpaqueY(x) {
+            x = Math.floor(x);
+            for (let y = 0; y < canvas.height; y++) {
+                if (data[(y * canvas.width + x) * 4 + 3] > 0) return y;
+            }
+            return -1;
+        }
 
-    // Drop more coins for a denser effect
-    setInterval(spawnCoin, 100);
+        function spawnCoin() {
+            let x, y;
+            do {
+                x = Math.random() * canvas.width;
+                y = getTopOpaqueY(x);
+            } while (y === -1);
+
+            const scaleX = container.clientWidth / canvas.width;
+            const scaleY = container.clientHeight / canvas.height;
+            const coin = document.createElement('div');
+            coin.className = 'coin';
+            coin.style.left = x * scaleX + 'px';
+            coin.style.setProperty('--start-top', y * scaleY - 35 + 'px');
+            container.appendChild(coin);
+            coin.addEventListener('animationend', () => coin.remove());
+        }
+
+        setInterval(spawnCoin, 100);
+    };
 }
 
 // MetaMask Wallet Connection

--- a/styles.css
+++ b/styles.css
@@ -136,6 +136,14 @@ section > p:not(.graph-source):not(.total-supply) {
     pointer-events: none;
     overflow: hidden;
     z-index: 10; /* place coins above the image */
+    -webkit-mask-image: url('textilepile.png');
+    mask-image: url('textilepile.png');
+    -webkit-mask-size: cover;
+    mask-size: cover;
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+    mask-position: center;
 }
 
 .coin {
@@ -145,12 +153,13 @@ section > p:not(.graph-source):not(.total-supply) {
     background-image: url('coins/thrift.png');
     background-size: contain;
     background-repeat: no-repeat;
+    top: var(--start-top, -10%);
     animation: coinFall 3s linear forwards;
     z-index: 11;
 }
 
 @keyframes coinFall {
-    0% { top: -10%; }
+    0% { top: var(--start-top, -10%); }
     100% { top: 110%; }
 }
 


### PR DESCRIPTION
## Summary
- Restrict coin animation to the mountain silhouette by masking and boundary-aware spawning
- Start each coin at the image's top boundary and animate the fall for a natural pile effect

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689939082ad483219579653ac0c4771b