### PR TITLE
Increase coin rain density for full image coverage

### DIFF
--- a/script.js
+++ b/script.js
@@ -267,7 +267,12 @@ function initCoinRain() {
             coin.addEventListener('animationend', () => coin.remove());
         }
 
-        setInterval(spawnCoin, 100);
+        // spawn multiple coins each interval so the entire image mountain is covered
+        setInterval(() => {
+            for (let i = 0; i < 5; i++) {
+                spawnCoin();
+            }
+        }, 100);
     };
 }
 


### PR DESCRIPTION
## Summary
- spawn multiple coins during each interval to cover the entire masked mountain image

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68993ab3f41c8321b0a06200bb09176f