### PR TITLE
Position chat and language buttons at bottom left with updated icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,13 +39,15 @@
             </ul>
         </div>
     </header>
-    <div class="language-container">
-        <button id="languageButton">Language</button>
-        <div id="google_translate_element" class="language-dropdown"></div>
-    </div>
     <button id="chatbotToggle" class="chatbot-toggle" aria-label="Open chat">
         <i class="fa-solid fa-comments"></i>
     </button>
+    <div class="language-container">
+        <button id="languageButton" aria-label="Change language">
+            <img src="translate.png" alt="Translate" />
+        </button>
+        <div id="google_translate_element" class="language-dropdown"></div>
+    </div>
     <div id="chatbot" class="chatbot hidden">
         <div class="chatbot-header">AI Assistant <span id="chatbotClose" class="chatbot-close">&times;</span></div>
         <div id="chatbotMessages" class="chatbot-messages"></div>

--- a/styles.css
+++ b/styles.css
@@ -286,8 +286,8 @@ section > p:not(.graph-source):not(.total-supply)::before {
 /* Language selector and chat toggle */
 .language-container {
     position: fixed;
-    top: 1rem;
-    left: 1rem;
+    bottom: 20px;
+    left: 90px;
     right: auto;
     display: flex;
     flex-direction: column;
@@ -300,18 +300,25 @@ section > p:not(.graph-source):not(.total-supply)::before {
     background-color: #c69cd9;
     border: 1px solid #000;
     color: #ffffff;
-    padding: 5px 10px;
-    font-size: 0.9rem;
-    font-weight: bold;
-    border-radius: 5px;
+    width: 45px;
+    height: 45px;
+    padding: 0;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     cursor: pointer;
+}
+.language-container button img {
+    width: 30px;
+    height: 30px;
 }
 .language-dropdown {
     display: none;
     position: absolute;
-    top: 100%;
+    bottom: 100%;
     left: 0;
-    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
 }
 .language-container.open .language-dropdown {
     display: block;
@@ -946,21 +953,27 @@ footer {
 .chatbot-toggle {
     position: fixed;
     bottom: 20px;
-    right: 20px;
-    display: block;
+    left: 20px;
+    right: auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     background-color: #c69cd9;
     border: 1px solid #000;
     color: #ffffff;
-    padding: 5px;
+    width: 60px;
+    height: 60px;
     border-radius: 50%;
     cursor: pointer;
     z-index: 10001;
+    font-size: 24px;
 }
 
 .chatbot {
     position: fixed;
-    bottom: 20px;
-    right: 20px;
+    bottom: 90px;
+    left: 20px;
+    right: auto;
     width: 300px;
     max-height: 400px;
     background: #fff;


### PR DESCRIPTION
## Summary
- Relocate AI chat toggle to bottom-left and enlarge its footprint.
- Swap language toggle text for translate.png icon and position alongside chat button.
- Adjust styling for new layout and sizes, including dropdown behavior.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b972959648321bd18afbf68f80ac4