### PR TITLE
Enlarge hub logo and textile pile

### DIFF
--- a/script.js
+++ b/script.js
@@ -317,14 +317,14 @@ function initRecycleAnimation() {
         ctx.fillStyle = '#ffb703';
         ctx.fillRect(hub.x - 5, hub.y + 5, 10, 10);
         if (hubImg.complete) {
-            ctx.drawImage(hubImg, hub.x - 10, hub.y - 5, 20, 10);
+            ctx.drawImage(hubImg, hub.x - 15, hub.y - 7.5, 30, 15);
         }
 
         // textile pile background on left side
         if (textileImg.complete) {
             ctx.filter = 'contrast(1.2) saturate(1.4)';
-            const texW = 60;
-            const texH = 40;
+            const texW = 90;
+            const texH = 60;
             ctx.drawImage(textileImg, 10, ground - texH, texW, texH);
             ctx.filter = 'none';
         }


### PR DESCRIPTION
## Summary
- Increase hub logo size for better visibility in animated canvas.
- Enlarge textile pile image to emphasize background visuals.

## Testing
- `node --check script.js && echo "syntax ok"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c876e7bcc8321a11c71953c88a749