### PR TITLE
Ensure drones visit textile pile or people before returning to hub

### DIFF
--- a/script.js
+++ b/script.js
@@ -423,13 +423,7 @@ function initRecycleAnimation() {
                 if (dist < 2) {
                     d.carry.push(d.target);
                     d.target.picked = true;
-                    const next = people.find(p => !p.picked);
-                    if (next) {
-                        d.state = 'toPerson';
-                        d.target = next;
-                    } else {
-                        d.state = 'toHub';
-                    }
+                    d.state = 'toHub';
                 } else {
                     d.x += (dx / dist) * 3;
                     d.y += (dy / dist) * 3;
@@ -440,12 +434,7 @@ function initRecycleAnimation() {
                 const dist = Math.hypot(dx, dy);
                 if (dist < 2) {
                     d.target.picked = true;
-                    const next = people.find(p => !p.picked);
-                    if (next) {
-                        d.target = next;
-                    } else {
-                        d.state = 'toHub';
-                    }
+                    d.state = 'toHub';
                 } else {
                     d.x += (dx / dist) * 3;
                     d.y += (dy / dist) * 3;


### PR DESCRIPTION
## Summary
- make drones head to the hub only after visiting either the textile pile or a person

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689c9248ec748321b2d9f64610895424