### PR TITLE
feat: add purchase ticker and wallet modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,11 +18,14 @@
     <script defer src="script.js"></script>
 </head>
 <body>
+    <div id="purchaseTicker" class="purchase-ticker">
+        <div id="tickerTrack" class="ticker-track"></div>
+    </div>
     <header>
         <div class="logo">
             <a href="index.html#hero"><img src="logo/thrifttoken.png" alt="Thrift Token Logo" /></a>
         </div>
-        <button id="connectWallet" class="wallet-button">Connect Wallet</button>
+        <button id="connectWallet" class="wallet-button">BUY $THRIFT</button>
         <div class="dropdown-arrow" onclick="toggleMenu()">&#9660;</div>
         <div class="dropdown-menu" id="dropdown-menu">
             <ul>
@@ -39,6 +42,18 @@
             </ul>
         </div>
     </header>
+    <div id="walletModal" class="modal hidden">
+        <div class="modal-content">
+            <span id="modalClose" class="modal-close">&times;</span>
+            <h3>Connect Wallet</h3>
+            <button class="wallet-option">Best Wallet <i class="fa-solid fa-wallet"></i></button>
+            <button class="wallet-option">WalletConnect <i class="fa-solid fa-link"></i></button>
+            <button class="wallet-option">MetaMask <img src="coins/MetaMask.png" alt="MetaMask logo"/></button>
+            <button class="wallet-option">Base Wallet <i class="fa-solid fa-rocket"></i></button>
+            <button class="wallet-option">Coinbase Wallet <i class="fa-solid fa-coins"></i></button>
+            <button class="wallet-option">Pay with Card <i class="fa-solid fa-credit-card"></i></button>
+        </div>
+    </div>
     <button id="chatbotToggle" class="chatbot-toggle" aria-label="Open chat">
         <i class="fa-solid fa-comments"></i>
     </button>

--- a/script.js
+++ b/script.js
@@ -569,6 +569,8 @@ function initRecycleAnimation() {
 // MetaMask Wallet Connection
 document.addEventListener("DOMContentLoaded", function () {
     const connectWalletBtn = document.getElementById("connectWallet");
+    const walletModal = document.getElementById("walletModal");
+    const modalClose = document.getElementById("modalClose");
     const languageBtn = document.getElementById("languageButton");
     const languageContainer = document.querySelector(".language-container");
     const chatToggle = document.getElementById("chatbotToggle");
@@ -578,18 +580,36 @@ document.addEventListener("DOMContentLoaded", function () {
     const chatSend = document.getElementById("chatbotSend");
     const chatMessages = document.getElementById("chatbotMessages");
 
-    connectWalletBtn.addEventListener("click", async () => {
-        if (typeof window.ethereum !== "undefined") {
-            try {
-                const accounts = await window.ethereum.request({ method: "eth_requestAccounts" });
-                connectWalletBtn.textContent = "Wallet: " + accounts[0].slice(0, 6) + "..." + accounts[0].slice(-4);
-            } catch (error) {
-                console.error("Wallet connection failed:", error);
-            }
-        } else {
-            alert("Please install MetaMask to use this feature.");
-        }
+    connectWalletBtn?.addEventListener("click", () => {
+        walletModal?.classList.remove("hidden");
     });
+    modalClose?.addEventListener("click", () => walletModal.classList.add("hidden"));
+    walletModal?.addEventListener("click", (e) => {
+        if (e.target === walletModal) walletModal.classList.add("hidden");
+    });
+
+    const tickerTrack = document.getElementById("tickerTrack");
+    if (tickerTrack) {
+        const purchases = [
+            "[0x4eA9...b0FC2] bought 14.7K $THRIFT worth $0.44",
+            "[0xd83A...41d66] bought 3K $THRIFT worth $38.30",
+            "[0x83C0...DC2dF] bought 648 $THRIFT worth $8.27",
+            "[0xBc22...5d7aE] bought 18.7K $THRIFT worth $238.90",
+            "[0xd83A...41d66] bought 7K $THRIFT worth $89.36",
+            "[0x53EF...417A5] bought 906 $THRIFT worth $11.57",
+            "[0x566E...0DaB5] bought 77.9K $THRIFT worth $994.50",
+            "[0x9F16...4a713] bought 86.7K $THRIFT worth $1106.85",
+            "[0xD7ad...E5bE4] bought 6.3K $THRIFT worth $80.90",
+            "[0xC076...7ad47] bought 50 $THRIFT worth $0.64"
+        ];
+        purchases.forEach(p => {
+            const span = document.createElement("span");
+            span.className = "purchase-item";
+            span.textContent = p;
+            tickerTrack.appendChild(span);
+        });
+        tickerTrack.innerHTML += tickerTrack.innerHTML;
+    }
 
     if (languageBtn && languageContainer) {
         languageBtn.addEventListener("click", () => {

--- a/styles.css
+++ b/styles.css
@@ -13,13 +13,13 @@ body {
     background-color: #ffffff;
     color: #000000;
     text-align: center;
-    padding-top: 120px; /* Space for fixed header */
+    padding-top: 160px; /* Space for ticker and fixed header */
 }
 
 /* Fixed header so logo, menu arrow, and wallet button stay visible */
 header {
     position: fixed;
-    top: 0;
+    top: 40px; /* below ticker */
     left: 0;
     width: 100%;
     background-color: #ffffff;
@@ -34,7 +34,7 @@ header {
 
 @media (max-width: 600px) {
     body {
-        padding-top: 120px;
+        padding-top: 160px;
     }
     .logo img {
         height: 50px;
@@ -43,7 +43,7 @@ header {
 
 @media (min-width: 769px) {
     body {
-        padding-top: 200px;
+        padding-top: 240px;
     }
 }
 
@@ -246,6 +246,7 @@ section > p:not(.graph-source):not(.total-supply)::before {
     border-radius: 8px;
     cursor: pointer;
     transition: background 0.3s ease;
+    box-shadow: 0 2px #000;
 }
 .wallet-button:hover {
     background-color: #b17cc7;
@@ -1036,4 +1037,83 @@ footer {
         display: block;
         margin: 0.5rem 0;
     }
+}
+
+/* Purchase ticker */
+.purchase-ticker {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 40px;
+    background: #fff;
+    border-bottom: 2px solid #000;
+    overflow: hidden;
+    z-index: 1000;
+}
+.ticker-track {
+    display: flex;
+    width: max-content;
+    animation: ticker 20s linear infinite;
+}
+.purchase-item {
+    padding: 0 1.5rem;
+    white-space: nowrap;
+    font-weight: bold;
+}
+@keyframes ticker {
+    from { transform: translateX(0); }
+    to { transform: translateX(-50%); }
+}
+
+/* Wallet modal */
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1001;
+}
+.modal.hidden { display: none; }
+.modal-content {
+    background: #e0e0e0;
+    border: 2px solid #000;
+    border-radius: 16px;
+    padding: 20px;
+    width: 90%;
+    max-width: 400px;
+    position: relative;
+    box-shadow: 0 2px #000;
+}
+.modal-close {
+    position: absolute;
+    top: 10px;
+    right: 15px;
+    cursor: pointer;
+    font-weight: bold;
+}
+.wallet-option {
+    background: #c69cd9;
+    color: #fff;
+    border: 2px solid #000;
+    border-radius: 8px;
+    padding: 10px 15px;
+    margin: 10px 0;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-weight: bold;
+    box-shadow: 0 2px #000;
+}
+.wallet-option img,
+.wallet-option i {
+    width: 24px;
+    height: 24px;
+    margin-left: 10px;
 }


### PR DESCRIPTION
## Summary
- add animated purchase ticker with fake $THRIFT buys
- replace Connect Wallet with "BUY $THRIFT" and show modal of wallet/card options
- style ticker and modal with cartoony purple buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a61fe1416483218349349922f4fdf7