### PR TITLE
Add labeled purchase ticker with fade effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,10 @@
 </head>
 <body>
     <div id="purchaseTicker" class="purchase-ticker">
-        <div id="tickerTrack" class="ticker-track"></div>
+        <span class="ticker-label">LATEST PURCHASES</span>
+        <div id="tickerWrapper" class="ticker-wrapper">
+            <div id="tickerTrack" class="ticker-track"></div>
+        </div>
     </div>
     <header>
         <div class="logo">

--- a/script.js
+++ b/script.js
@@ -610,7 +610,7 @@ document.addEventListener("DOMContentLoaded", function () {
     });
 
     const tickerTrack = document.getElementById("tickerTrack");
-    const tickerContainer = document.getElementById("purchaseTicker");
+    const tickerContainer = document.getElementById("tickerWrapper");
     if (tickerTrack && tickerContainer) {
         const purchases = [
             "[0x4eA9...b0FC2] bought 14.7K $THRIFT worth $0.44",

--- a/styles.css
+++ b/styles.css
@@ -1082,6 +1082,30 @@ footer {
     border-bottom: 2px solid #000;
     overflow: hidden;
     z-index: 1000;
+    display: flex;
+    align-items: center;
+}
+.ticker-label {
+    margin-left: 10px;
+    font-weight: bold;
+    position: relative;
+    z-index: 2;
+}
+.ticker-wrapper {
+    flex: 1;
+    overflow: hidden;
+    position: relative;
+}
+.ticker-wrapper::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 60px;
+    height: 100%;
+    background: linear-gradient(to right, #fff 0%, rgba(255,255,255,0) 100%);
+    z-index: 1;
+    pointer-events: none;
 }
 .ticker-track {
     display: inline-block;


### PR DESCRIPTION
## Summary
- Add left-aligned "LATEST PURCHASES" label to the purchase ticker
- Wrap ticker content to ensure consistent scrolling and add gradient fade-out before the label
- Adjust JS to build ticker within new wrapper for responsive behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a62acfc6ec83218da3ea3b978e1c1f