### PR TITLE
Slow purchase ticker animation

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1111,8 +1111,8 @@ footer {
     display: inline-block;
     white-space: nowrap;
     will-change: transform;
-    animation: ticker 20s linear infinite;
-    -webkit-animation: ticker 20s linear infinite;
+    animation: ticker 50s linear infinite;
+    -webkit-animation: ticker 50s linear infinite;
 }
 .purchase-item {
     padding: 0 1.5rem;


### PR DESCRIPTION
## Summary
- Slow the latest purchases ticker to 50s per loop (~60% slower) for desktop and mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a639beacf48321b960d5b1c0e1110f