### PR TITLE
fix: keep purchase ticker animation running

### DIFF
--- a/script.js
+++ b/script.js
@@ -652,8 +652,13 @@ document.addEventListener("DOMContentLoaded", function () {
         tickerTrack.style.webkitAnimation = "";
     }
 
+    let lastTickerWidth = window.innerWidth;
     initPurchaseTicker();
-    window.addEventListener("resize", initPurchaseTicker);
+    window.addEventListener("resize", () => {
+        if (window.innerWidth === lastTickerWidth) return;
+        lastTickerWidth = window.innerWidth;
+        initPurchaseTicker();
+    });
 
     if (languageBtn && languageContainer) {
         languageBtn.addEventListener("click", () => {

--- a/styles.css
+++ b/styles.css
@@ -1084,6 +1084,7 @@ footer {
     z-index: 1000;
     display: flex;
     align-items: center;
+    pointer-events: none;
 }
 .ticker-label {
     margin-left: 10px;


### PR DESCRIPTION
## Summary
- prevent purchase ticker from resetting during window height changes
- disable pointer events on ticker to avoid scroll interference

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a64a821004832188234f3a9b87699e