### PR TITLE
style: enhance presale countdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,6 @@
     <section id="hero">
         <div id="icoHero" class="ico-hero">
             <button id="presaleButton" class="presale-button">PRESALE IS LIVE</button>
-            <h2 class="buy-now">BUY $THRIFT NOW!</h2>
             <div id="countdown" class="countdown"></div>
             <div class="ico-bar">
                 <div id="icoBarFill" class="ico-bar-fill"></div>

--- a/script.js
+++ b/script.js
@@ -18,21 +18,24 @@ function updateCountdown() {
     const secs = Math.floor((distance % (1000 * 60)) / 1000);
 
     countdown.innerHTML = `
-        <div class="time-segment">
-            <span class="count-label">DAYS</span>
-            <span class="count-num">${String(days).padStart(2, '0')}</span>
-        </div>
-        <div class="time-segment">
-            <span class="count-label">HOURS</span>
-            <span class="count-num">${String(hrs).padStart(2, '0')}</span>
-        </div>
-        <div class="time-segment">
-            <span class="count-label">MINUTES</span>
-            <span class="count-num">${String(mins).padStart(2, '0')}</span>
-        </div>
-        <div class="time-segment">
-            <span class="count-label">SECONDS</span>
-            <span class="count-num">${String(secs).padStart(2, '0')}</span>
+        <div class="launch-title">Days till Launch! <i class="fa-solid fa-rocket launch-rocket"></i></div>
+        <div class="time-wrapper">
+            <div class="time-segment">
+                <span class="count-label">DAYS</span>
+                <span class="count-num">${String(days).padStart(2, '0')}</span>
+            </div>
+            <div class="time-segment">
+                <span class="count-label">HOURS</span>
+                <span class="count-num">${String(hrs).padStart(2, '0')}</span>
+            </div>
+            <div class="time-segment">
+                <span class="count-label">MINUTES</span>
+                <span class="count-num">${String(mins).padStart(2, '0')}</span>
+            </div>
+            <div class="time-segment">
+                <span class="count-label">SECONDS</span>
+                <span class="count-num">${String(secs).padStart(2, '0')}</span>
+            </div>
         </div>`;
 }
 setInterval(updateCountdown, 1000);
@@ -63,7 +66,7 @@ function initPresaleButton() {
     const btn = document.getElementById("presaleButton");
     if (!btn) return;
     const liveText = "PRESALE IS LIVE";
-    const buyText = "BUY $THRIFT";
+    const buyText = "BUY $THRIFT NOW!";
     btn.addEventListener("mouseover", () => (btn.textContent = buyText));
     btn.addEventListener("mouseout", () => (btn.textContent = liveText));
     btn.addEventListener("click", () => (btn.textContent = buyText));

--- a/styles.css
+++ b/styles.css
@@ -240,21 +240,25 @@ section > p:not(.graph-source):not(.total-supply)::before {
 }
 
 /* Wallet button */
-.wallet-button {
-    background-color: #c69cd9;
-    border: 1px solid #000;
-    color: #ffffff;
+.wallet-button,
+.presale-button {
+    background-color: #000;
+    border: 2px solid #00ff00;
+    color: #00ff00;
     padding: 10px 20px;
     margin: 0.5rem 0 0;
     font-size: 1rem;
     font-weight: bold;
     border-radius: 8px;
     cursor: pointer;
-    transition: background 0.3s ease;
-    box-shadow: 0 2px #000;
+    transition: background 0.3s ease, color 0.3s ease;
+    box-shadow: 0 2px #00ff00;
 }
-.wallet-button:hover {
-    background-color: #b17cc7;
+.presale-button { margin: 0 0 1rem; }
+.wallet-button:hover,
+.presale-button:hover {
+    background-color: #00ff00;
+    color: #000;
 }
 
 /* Language selector and chat toggle */
@@ -355,22 +359,50 @@ section > p:not(.graph-source):not(.total-supply)::before {
     content: "";
     position: absolute;
     top: 0; left: 0; width: 100%; height: 100%;
-    background-image: repeating-linear-gradient(0deg, rgba(255,255,255,0.05) 1px, transparent 1px, transparent 20px),
-                      repeating-linear-gradient(90deg, rgba(255,255,255,0.05) 1px, transparent 1px, transparent 20px);
+    background-image: repeating-linear-gradient(0deg, rgba(0,255,0,0.1) 1px, transparent 1px, transparent 20px),
+                      repeating-linear-gradient(90deg, rgba(0,255,0,0.1) 1px, transparent 1px, transparent 20px);
     z-index: 0;
 }
 #countdown {
     display: flex;
+    flex-direction: column;
+    align-items: center;
     justify-content: center;
     gap: 0.5rem;
     font-size: clamp(1.5rem, 4vw, 3rem);
-    color: #c69cd9;
+    color: #00ff00;
     z-index: 1;
     position: relative;
     background-color: #000;
+    border: 2px solid #00ff00;
     padding: 0.5rem 1rem;
     width: fit-content;
     margin: 0 auto;
+}
+
+.time-wrapper {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.launch-title {
+    font-size: 1rem;
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: #00ff00;
+}
+
+.launch-rocket {
+    animation: rocket 2s infinite ease-in-out;
+}
+
+@keyframes rocket {
+    0% { transform: translateY(0); }
+    50% { transform: translate(-3px, -10px); }
+    100% { transform: translateY(0); }
 }
 
 .time-segment {
@@ -378,69 +410,54 @@ section > p:not(.graph-source):not(.total-supply)::before {
     flex-direction: column;
     align-items: center;
     padding: 0 0.5rem;
-    border-left: 1px solid #c69cd9;
+    border-left: 1px solid #00ff00;
 }
 
 .time-segment:first-child {
     border-left: none;
 }
 
+
 .count-num {
     font-weight: bold;
-    color: #c69cd9;
+    color: #00ff00;
 }
+
 
 .count-label {
     font-size: 0.6em;
     margin-bottom: 0.2rem;
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    color: #c69cd9;
+    color: #00ff00;
 }
 
 .ico-hero {
     margin-top: 1rem;
-    background: #fff;
-    border: 2px solid #c69cd9;
-    box-shadow: 4px 4px 0 #000;
+    background: #000;
+    border: 2px solid #00ff00;
+    box-shadow: 4px 4px 0 #00ff00;
     padding: 2rem 1rem;
     max-width: 600px;
     margin-left: auto;
     margin-right: auto;
+    color: #00ff00;
 }
 
-.presale-button {
-    background: #c69cd9;
-    color: #000;
-    font-weight: bold;
-    padding: 0.75rem 1.5rem;
-    border: 2px solid #000;
-    cursor: pointer;
-    margin-bottom: 1rem;
-}
-
-.presale-button:hover {
-    background: #000;
-    color: #fff;
-}
-
-.buy-now {
-    margin-bottom: 1rem;
-    font-weight: bold;
-}
 
 .ico-bar {
     width: 80%;
     height: 20px;
-    border: 2px solid #c69cd9;
+    border: 2px solid #00ff00;
     background: #000;
     margin: 1rem auto;
     position: relative;
 }
 
+
 .ico-bar-fill {
     height: 100%;
-    background: #c69cd9;
+    background: #00ff00;
     width: 0;
 }
 
@@ -457,8 +474,9 @@ section > p:not(.graph-source):not(.total-supply)::before {
     margin-top: 1rem;
 }
 
+
 .w3p-logo {
-    color: #c69cd9;
+    color: #00ff00;
 }
 
 .powered-by {


### PR DESCRIPTION
## Summary
- Redesign presale hero with a single call-to-action button that flips to "BUY $THRIFT NOW!" on hover or click
- Add matrix-green countdown labeled "Days till Launch!" and animate a rocket icon
- Apply matching matrix color scheme to buttons, countdown, and progress bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a730576f0483218959aa4e95f4a72a