### PR TITLE
Slow USD raised animation and dynamic goal

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
             <div class="ico-bar">
                 <div id="icoBarFill" class="ico-bar-fill"></div>
             </div>
-            <p class="ico-raised">USD RAISED: <span id="usdRaised">$0</span> / <span id="usdGoal">$10,000.00</span></p>
+            <p class="ico-raised">USD RAISED: <span id="usdRaised">$0</span> / <span id="usdGoal">$0.00</span></p>
             <p class="ico-note">UNTIL PRICE RISE</p>
             <p class="ico-price">1 $THRIFT = <span id="thriftPrice">$0.10</span></p>
             <p class="ico-wallet">Don't have a wallet?<br/><span class="powered-by">Powered by <span class="w3p-logo">w3p</span></span></p>

--- a/script.js
+++ b/script.js
@@ -41,15 +41,24 @@ function updateCountdown() {
 setInterval(updateCountdown, 1000);
 updateCountdown();
 
+let icoGoal = 0;
+function setIcoGoal(newGoal) {
+    icoGoal = newGoal;
+    const goalEl = document.getElementById("usdGoal");
+    if (goalEl) {
+        goalEl.textContent = "$" + icoGoal.toLocaleString(undefined, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+        });
+    }
+}
+
 function initHeroIcoProgress() {
     const raisedEl = document.getElementById("usdRaised");
-    const goalEl = document.getElementById("usdGoal");
     const barFill = document.getElementById("icoBarFill");
-    if (!(raisedEl && goalEl && barFill)) return;
+    if (!(raisedEl && barFill)) return;
 
-    const goal = 10_000;
-    goalEl.textContent = "$" + goal.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-    const duration = 3000;
+    const duration = 7500; // 60% slower than previous 3000ms
     let start;
 
     function step(now) {
@@ -59,9 +68,13 @@ function initHeroIcoProgress() {
             start = now;
             progress = 0;
         }
-        const current = goal * progress;
-        raisedEl.textContent = "$" + current.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-        barFill.style.width = (current / goal * 100) + "%";
+        const current = icoGoal * progress;
+        raisedEl.textContent = "$" + current.toLocaleString(undefined, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+        });
+        const width = icoGoal ? (current / icoGoal * 100) : 0;
+        barFill.style.width = width + "%";
         requestAnimationFrame(step);
     }
 
@@ -76,8 +89,9 @@ async function updateLivePrices() {
         const data = await res.json();
         const matic = data["matic-network"].usd;
         const eth = data["ethereum"].usd;
-        const thriftPrice = ((matic + eth) * 0.0001).toFixed(4);
-        priceEl.textContent = `$${thriftPrice}`;
+        const thriftPriceNum = (matic + eth) * 0.0001;
+        priceEl.textContent = `$${thriftPriceNum.toFixed(4)}`;
+        setIcoGoal(thriftPriceNum * 90_000_000);
     } catch (e) {
         priceEl.textContent = "$0.10";
     }


### PR DESCRIPTION
## Summary
- Slow the USD raised animation by roughly 60% for a more natural progression.
- Replace the static $10k goal with a live value based on current MATIC/ETH pricing and a 90M token supply.
- Default goal display shows $0 while waiting for live data.

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a73d0b0dbc83218fea63c647b8fadf