### PR TITLE
Place UNTIL PRICE RISE message inside progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,9 +85,9 @@
             <div id="countdown" class="countdown"></div>
             <div class="ico-bar">
                 <div id="icoBarFill" class="ico-bar-fill"></div>
+                <p class="ico-note">UNTIL PRICE RISE</p>
             </div>
             <p class="ico-raised">USD RAISED: <span id="usdRaised">$0</span> / <span id="usdGoal">$11,000.00</span></p>
-            <p class="ico-note">UNTIL PRICE RISE</p>
             <p class="ico-price">1 $THRIFT = <span id="thriftPrice">$0.10</span></p>
             <p class="ico-wallet">Don't have a wallet?<br/><span class="powered-by">Powered by <span class="w3p-logo">w3p</span></span></p>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -528,10 +528,21 @@ section > p:not(.graph-source):not(.total-supply)::before {
 }
 
 .ico-raised,
-.ico-note,
 .ico-price,
 .ico-wallet {
     margin: 0.25rem 0;
+    font-weight: bold;
+}
+
+.ico-note {
+    color: #fff;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 100%;
+    margin: 0;
+    text-align: center;
     font-weight: bold;
 }
 


### PR DESCRIPTION
## Summary
- Move UNTIL PRICE RISE note into the animated ICO progress bar
- Center and style note text in white for better contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a750aa1b748321897fd8b986b6a05c