### PR TITLE
Center countdown and scale up Web3 logo

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -379,7 +379,7 @@ section > p:not(.graph-source):not(.total-supply)::before {
     z-index: 0;
 }
 #countdown {
-    display: inline-flex;
+    display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
@@ -391,9 +391,10 @@ section > p:not(.graph-source):not(.total-supply)::before {
     background-color: #000;
     border: 2px solid #00ff00;
     padding: 0.5rem 1rem;
-    margin: 0 auto;
+    margin-left: auto;
+    margin-right: auto;
     text-align: center;
-    align-self: center;
+    width: fit-content;
 }
 
 .time-wrapper {
@@ -557,7 +558,7 @@ section > p:not(.graph-source):not(.total-supply)::before {
 
 .w3p-logo {
     display: inline-block;
-    height: 0.8em;
+    height: 2.4em;
     vertical-align: middle;
 }
 
@@ -572,11 +573,13 @@ section > p:not(.graph-source):not(.total-supply)::before {
     }
 
     #countdown {
-        display: inline-flex;
+        display: flex;
         font-size: clamp(1.5rem, 8vw, 2.5rem);
         gap: 0.25rem;
         padding: 0.25rem 0.5rem;
-        margin: 0 auto;
+        margin-left: auto;
+        margin-right: auto;
+        width: fit-content;
     }
 
     .time-segment {
@@ -584,7 +587,7 @@ section > p:not(.graph-source):not(.total-supply)::before {
     }
 
     .w3p-logo {
-        height: 1.2em;
+        height: 2.4em;
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure countdown timer uses flex layout and auto margins so it stays centered inside the metal box across screen sizes
- enlarge Web3 Payments logo to improve visibility on both desktop and mobile

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bbd956fc8321a2b8307d815a9bb3