### PR TITLE
Add wallet redirects and whitepaper button shadow

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,12 +49,12 @@
         <div class="modal-content">
             <span id="modalClose" class="modal-close">&times;</span>
             <h3>Connect Wallet</h3>
-            <button class="wallet-option">Best Wallet <i class="fa-solid fa-wallet"></i></button>
-            <button class="wallet-option">WalletConnect <i class="fa-solid fa-link"></i></button>
-            <button class="wallet-option">MetaMask <img src="coins/MetaMask.png" alt="MetaMask logo"/></button>
-            <button class="wallet-option">Base Wallet <i class="fa-solid fa-rocket"></i></button>
-            <button class="wallet-option">Coinbase Wallet <i class="fa-solid fa-coins"></i></button>
-            <button class="wallet-option">Pay with Card <i class="fa-solid fa-credit-card"></i></button>
+            <button class="wallet-option" data-url="https://bestwallet.com">Best Wallet <i class="fa-solid fa-wallet"></i></button>
+            <button class="wallet-option" data-url="https://walletconnect.com">WalletConnect <i class="fa-solid fa-link"></i></button>
+            <button class="wallet-option" data-url="https://metamask.io/download/">MetaMask <img src="coins/MetaMask.png" alt="MetaMask logo"/></button>
+            <button class="wallet-option" data-url="https://www.base.org/wallet">Base Wallet <i class="fa-solid fa-rocket"></i></button>
+            <button class="wallet-option" data-url="https://www.coinbase.com/wallet">Coinbase Wallet <i class="fa-solid fa-coins"></i></button>
+            <button class="wallet-option" data-url="https://web3paymentsolutions.io">Pay with Card <i class="fa-solid fa-credit-card"></i></button>
         </div>
     </div>
     <div id="walletInfoModal" class="modal hidden">

--- a/script.js
+++ b/script.js
@@ -646,6 +646,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const walletInfoLink = document.getElementById("walletInfoLink");
     const walletInfoModal = document.getElementById("walletInfoModal");
     const walletInfoClose = document.getElementById("walletInfoClose");
+    const walletOptions = document.querySelectorAll(".wallet-option");
 
     connectWalletBtn?.addEventListener("click", () => {
         walletModal?.classList.remove("hidden");
@@ -662,6 +663,16 @@ document.addEventListener("DOMContentLoaded", function () {
     walletInfoClose?.addEventListener("click", () => walletInfoModal?.classList.add("hidden"));
     walletInfoModal?.addEventListener("click", (e) => {
         if (e.target === walletInfoModal) walletInfoModal.classList.add("hidden");
+    });
+
+    walletOptions.forEach(option => {
+        option.addEventListener("click", () => {
+            const url = option.getAttribute("data-url");
+            if (url) {
+                window.open(url, "_blank", "noopener");
+                walletModal?.classList.add("hidden");
+            }
+        });
     });
 
     function initPurchaseTicker() {

--- a/styles.css
+++ b/styles.css
@@ -1057,6 +1057,7 @@ footer {
     cursor: pointer;
     transition: background 0.3s ease;
     display: inline-block;
+    box-shadow: 0 2px #000;
 }
 
 .whitepaper-button:hover {


### PR DESCRIPTION
## Summary
- Give the whitepaper link the same drop shadow styling as the Buy $THRIFT button
- Add data URLs for each wallet option so users are redirected to the proper wallet pages
- Wire wallet-option buttons to open their targets and hide the modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bceeb4e48321b155c2cf62137245