### PR TITLE
Ensure countdown timer stays centered within metal box

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -395,12 +395,16 @@ section > p:not(.graph-source):not(.total-supply)::before {
     margin-right: auto;
     text-align: center;
     width: fit-content;
+    max-width: 100%;
+    box-sizing: border-box;
 }
 
 .time-wrapper {
     display: flex;
     justify-content: center;
     gap: 0.5rem;
+    flex-wrap: wrap;
+    width: 100%;
 }
 
 .launch-title {
@@ -580,6 +584,8 @@ section > p:not(.graph-source):not(.total-supply)::before {
         margin-left: auto;
         margin-right: auto;
         width: fit-content;
+        max-width: 100%;
+        box-sizing: border-box;
     }
 
     .time-segment {


### PR DESCRIPTION
## Summary
- Prevent countdown timer from overflowing by limiting its width and wrapping segments
- Make countdown responsive across screen sizes with consistent box sizing

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bfb4050883218682172da85cb3a1