### PR TITLE
Ensure countdown timer stays on one line on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -588,6 +588,12 @@ section > p:not(.graph-source):not(.total-supply)::before {
         box-sizing: border-box;
     }
 
+    .time-wrapper {
+        flex-wrap: nowrap;
+        gap: 0.25rem;
+        width: fit-content;
+    }
+
     .time-segment {
         padding: 0 0.25rem;
     }


### PR DESCRIPTION
## Summary
- prevent countdown timer from wrapping on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c4eade308321932e9525c2950cd2