### PR TITLE
Add directional icons to tug-of-war metrics

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,8 +122,8 @@
             <div id="wasteBar" class="tug-bar waste"></div>
         </div>
         <div class="tug-labels">
-            <span id="tokenCount" class="token-label">0 Thrift Tokens</span>
-            <span id="wasteCount" class="waste-label">92,000,000,000 kg Waste</span>
+            <span class="token-label"><i class="fa-solid fa-arrow-trend-up"></i> <span id="tokenValue">0 Thrift Tokens</span></span>
+            <span class="waste-label"><i class="fa-solid fa-arrow-trend-down"></i> <span id="wasteValue">92,000,000,000 kg Waste</span></span>
         </div>
         <h3><i class="fa-solid fa-chart-column section-icon red-icon" aria-hidden="true"></i>Landfill Fiber Comparison <br><span class="annual-count">(Annual Count)</span></h3>
         <p>Annual landfill textile waste by material, used to project future trajectory.</p>

--- a/script.js
+++ b/script.js
@@ -111,9 +111,9 @@ function toggleMenu() {
 function initTugOfWar() {
     const tokenBar = document.getElementById("tokenBar");
     const wasteBar = document.getElementById("wasteBar");
-    const tokenCount = document.getElementById("tokenCount");
-    const wasteCount = document.getElementById("wasteCount");
-    if (!tokenBar || !wasteBar) return;
+    const tokenValue = document.getElementById("tokenValue");
+    const wasteValue = document.getElementById("wasteValue");
+    if (!tokenBar || !wasteBar || !tokenValue || !wasteValue) return;
 
     const maxTokens = 92_000_000;
     const maxWaste = 92_000_000_000; // kg (92 million tons)
@@ -132,8 +132,8 @@ function initTugOfWar() {
         tokenBar.style.width = progress * 100 + "%";
         wasteBar.style.width = (1 - progress) * 100 + "%";
 
-        tokenCount.textContent = Math.round(tokens).toLocaleString() + " Thrift Tokens";
-        wasteCount.textContent = Math.round(waste).toLocaleString() + " kg Waste";
+        tokenValue.textContent = Math.round(tokens).toLocaleString() + " Thrift Tokens";
+        wasteValue.textContent = Math.round(waste).toLocaleString() + " kg Waste";
     }
 
     step();

--- a/styles.css
+++ b/styles.css
@@ -109,7 +109,10 @@ section > p:not(.graph-source):not(.total-supply) {
     color: #c69cd9;
 }
 .tug-labels .waste-label {
-    color: #c69cd9;
+    color: #ff0000;
+}
+.tug-labels i {
+    margin-right: 0.25rem;
 }
 
 .annual-count {


### PR DESCRIPTION
## Summary
- Add Font Awesome trend arrows for Thrift Tokens and kg Waste counts
- Style tug-of-war labels with purple and red text and matching icons
- Update animation script to target new value containers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ce2501708321b5f3a7ee209d732d