### PR TITLE
style: apply metal-box design to info sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,17 +142,17 @@
     <section id="how-to-buy">
         <h2><i class="fa-solid fa-wallet section-icon" aria-hidden="true"></i>HOW TO PREPARE</h2>
         <div class="steps">
-            <div class="step">
+            <div class="step metal-box">
                 <img src="coins/MetaMask.png" alt="MetaMask logo" class="step-icon"/>
                 <h3>1. INSTALL METAMASK</h3>
                 <p>Download MetaMask and set up your wallet.</p>
             </div>
-            <div class="step">
+            <div class="step metal-box">
                 <img src="coins/polygon.png" alt="Polygon logo" class="step-icon"/>
                 <h3>2. SWITCH TO POLYGON</h3>
                 <p>Add the Polygon network to your wallet settings.</p>
             </div>
-            <div class="step">
+            <div class="step metal-box">
                 <div class="step-icons">
                     <img src="coins/matic.png" alt="MATIC logo" class="step-icon"/>
                     <img src="coins/usdt.png" alt="USDT logo" class="step-icon"/>
@@ -160,7 +160,7 @@
                 <h3>3. FUND WALLET</h3>
                 <p>Transfer MATIC or USDT tokens to your wallet address.</p>
             </div>
-            <div class="step">
+            <div class="step metal-box">
                 <img src="coins/thrift.png" alt="Thrift Token logo" class="step-icon thrift-coin"/>
                 <h3>4. STAY TUNED</h3>
                 <p>Thrift Token presale opens soon!</p>
@@ -171,22 +171,22 @@
     <section id="features">
         <h2><i class="fa-solid fa-star section-icon gold-icon" aria-hidden="true"></i>WHY THRIFT TOKEN?</h2>
         <div class="features-grid">
-            <div class="feature-card">
+            <div class="feature-card metal-box">
                 <i class="fa-solid fa-globe feature-icon blue-glow-icon" aria-hidden="true"></i>
                 <h3>WEB3 ECOSYSTEM</h3>
                 <p>Built on Polygon for speed, scalability & low fees.</p>
             </div>
-            <div class="feature-card">
+            <div class="feature-card metal-box">
                 <i class="fa-solid fa-hand-holding-heart feature-icon pink-icon" aria-hidden="true"></i>
                 <h3>TRANSPARENT DONATIONS</h3>
                 <p>Track clothing distribution and impact in real-time.</p>
             </div>
-            <div class="feature-card">
+            <div class="feature-card metal-box">
                 <i class="fa-solid fa-recycle feature-icon green-icon" aria-hidden="true"></i>
                 <h3>FIBER SEPARATION TECH</h3>
                 <p>Support textile recycling & responsible fashion.</p>
             </div>
-            <div class="feature-card">
+            <div class="feature-card metal-box">
                 <i class="fa-solid fa-gavel feature-icon" aria-hidden="true"></i>
                 <h3>DAO GOVERNANCE</h3>
                 <p>Community-led decisions with staking power.</p>
@@ -208,27 +208,27 @@
     <section id="dapp">
         <h2><i class="fa-solid fa-mobile-screen section-icon" aria-hidden="true"></i>THRIFT.NETWORK DAPP</h2>
         <div class="features-grid">
-            <div class="feature-card">
+            <div class="feature-card metal-box">
                 <i class="fa-solid fa-infinity feature-icon cartoon" aria-hidden="true"></i>
                 <h3>INFINITE WARDROBE</h3>
                 <p>Browse a virtual closet of thrift clothing filtered by size, style, and preference.</p>
             </div>
-            <div class="feature-card">
+            <div class="feature-card metal-box">
                 <i class="fa-solid fa-arrows-rotate feature-icon cartoon green-icon" aria-hidden="true"></i>
                 <h3>WARDROBE SWAPS</h3>
                 <p>Trade your old clothes for Thrift Tokens and refresh your look with secondhand finds.</p>
             </div>
-            <div class="feature-card">
+            <div class="feature-card metal-box">
                 <i class="fa-solid fa-vr-cardboard feature-icon cartoon blue-glow-icon" aria-hidden="true"></i>
                 <h3>AUGMENTED REALITY FITTING</h3>
                 <p>Preview how garments will look using AR technology.</p>
             </div>
-            <div class="feature-card">
+            <div class="feature-card metal-box">
                 <i class="fa-solid fa-gamepad feature-icon cartoon" aria-hidden="true"></i>
                 <h3>GAMIFICATION</h3>
                 <p>Earn badges, rewards, and extra tokens for milestones like "10th Swap" or "100 Pounds Recycled."</p>
             </div>
-            <div class="feature-card">
+            <div class="feature-card metal-box">
                 <i class="fa-solid fa-robot feature-icon cartoon blue-glow-icon" aria-hidden="true"></i>
                 <h3>AI-DRIVEN SUGGESTIONS</h3>
                 <p>Personalized recommendations based on your style and inventory trends.</p>
@@ -239,15 +239,15 @@
     <section id="fiber-tech">
         <h2><i class="fa-solid fa-flask section-icon" aria-hidden="true"></i>FIBER SEPARATION TECHNOLOGY</h2>
         <div class="features-grid">
-            <div class="feature-card">
+            <div class="feature-card metal-box">
                 <i class="fa-solid fa-vial feature-icon cartoon green-icon" aria-hidden="true"></i>
                 <p>Chemical recycling methods to safely separate synthetic and natural fibers.</p>
             </div>
-            <div class="feature-card">
+            <div class="feature-card metal-box">
                 <i class="fa-solid fa-gears feature-icon cartoon blue-glow-icon" aria-hidden="true"></i>
                 <p>Mechanical processes with advanced sorting for blended fabrics.</p>
             </div>
-            <div class="feature-card">
+            <div class="feature-card metal-box">
                 <i class="fa-solid fa-brain feature-icon cartoon pink-icon" aria-hidden="true"></i>
                 <p>AI-powered assessment to identify optimal recycling paths for different textiles.</p>
             </div>
@@ -257,19 +257,19 @@
     <section id="hubs">
         <h2><i class="fa-solid fa-store section-icon" aria-hidden="true"></i>THRIFT NETWORK HUBS</h2>
         <div class="features-grid">
-            <div class="feature-card">
+            <div class="feature-card metal-box">
                 <i class="fa-solid fa-box-open feature-icon cartoon" aria-hidden="true"></i>
                 <p>Garment drop-off points where users receive Thrift Tokens for donations.</p>
             </div>
-            <div class="feature-card">
+            <div class="feature-card metal-box">
                 <i class="fa-solid fa-recycle feature-icon cartoon green-icon" aria-hidden="true"></i>
                 <p>Recycling centers using cutting-edge fiber separation technology.</p>
             </div>
-            <div class="feature-card">
+            <div class="feature-card metal-box">
                 <i class="fa-solid fa-truck feature-icon cartoon" aria-hidden="true"></i>
                 <p>Redistribution hubs that clean and deliver garments to underserved populations.</p>
             </div>
-            <div class="feature-card">
+            <div class="feature-card metal-box">
                 <i class="fa-solid fa-people-group feature-icon cartoon blue-glow-icon" aria-hidden="true"></i>
                 <p>Community engagement through educational workshops and sustainability events.</p>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -628,11 +628,7 @@ section > p:not(.graph-source):not(.total-supply)::before {
     max-width: 1000px;
 }
 .feature-card, .step {
-    background: #fff;
     padding: 1rem;
-    border: 2px solid #c69cd9;
-    border-radius: 10px;
-    box-shadow: 4px 4px 0 #000;
     flex: 1 1 200px;
     font-weight: bold;
 }


### PR DESCRIPTION
## Summary
- convert how-to-prepare steps and feature cards to use metal-box styling
- streamline step and feature CSS to allow metal box backgrounds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d5f824c8832192453ec2db333810