### PR TITLE
Fix countdown timer wrapping on desktop

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -418,8 +418,8 @@ section > p:not(.graph-source):not(.total-supply)::before {
     display: flex;
     justify-content: center;
     gap: 0.5rem;
-    flex-wrap: wrap;
-    width: 100%;
+    flex-wrap: nowrap;
+    width: fit-content;
 }
 
 .launch-title {


### PR DESCRIPTION
## Summary
- Prevent countdown timer segments from wrapping on desktop so countdown stays on one row

## Testing
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a7da212d4883219e8eeeded81c67f6