### PR TITLE
Expose notebook-style background for info box

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -63,7 +63,7 @@ section > p {
     line-height: 1.6;
 }
 
-section > p:not(.graph-source):not(.total-supply) {
+section > p:not(.graph-source):not(.total-supply):not(.info-box) {
     font-weight: bold;
     background: #fff;
     border: 2px solid #c69cd9;
@@ -177,6 +177,7 @@ section > p:not(.graph-source):not(.total-supply)::before {
     margin: 1rem auto;
     max-width: 800px;
     line-height: 25px;
+    font-weight: bold;
 }
 
 .section-list {


### PR DESCRIPTION
## Summary
- Prevent mission paragraph from using generic white box styling
- Keep info box text bold and notebook-like for better emphasis

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a6258a7883218210b58adff092a2