### PR TITLE
Apply notebook paper background to chart info and vision section

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,13 +126,13 @@
             <span class="waste-label"><i class="fa-solid fa-arrow-trend-down"></i> <span id="wasteValue">92,000,000,000 kg Waste</span></span>
         </div>
         <h3><i class="fa-solid fa-chart-column section-icon red-icon" aria-hidden="true"></i>LANDFILL FIBER COMPARISON <br><span class="annual-count">(ANNUAL COUNT)</span></h3>
-        <p>Annual landfill textile waste by material, used to project future trajectory.</p>
+        <p class="info-box">Annual landfill textile waste by material, used to project future trajectory.</p>
         <div class="chart-container">
             <canvas id="fiberComparisonChart"></canvas>
         </div>
         <p class="graph-source">Source: <a href="https://www.epa.gov/facts-and-figures-about-materials-waste-and-recycling/textiles-material-specific-data" target="_blank" rel="noopener">EPA Textile Waste Data</a></p>
         <h3><i class="fa-solid fa-chart-line section-icon red-icon" aria-hidden="true"></i>UNWANTED CLOTHING ITEMS <br><span class="annual-count">(ANNUAL COUNT)</span></h3>
-        <p>Annual count of unwanted clothing items in thrifts, illustrating projected trajectory.</p>
+        <p class="info-box">Annual count of unwanted clothing items in thrifts, illustrating projected trajectory.</p>
         <div class="chart-container">
             <canvas id="polyesterChart"></canvas>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -202,10 +202,27 @@ section > p:not(.graph-source):not(.total-supply)::before {
 }
 
 .vision-board li {
-    background: #fff;
+    background-color: #fdfbf7;
+    background-image:
+        linear-gradient(
+            to right,
+            transparent 40px,
+            #ffb3ba 40px,
+            #ffb3ba 42px,
+            transparent 42px
+        ),
+        repeating-linear-gradient(
+            to bottom,
+            #fdfbf7,
+            #fdfbf7 24px,
+            #c3d4f7 24px,
+            #c3d4f7 25px
+        );
+    background-repeat: no-repeat, repeat;
+    background-size: 100% 100%, 100% 25px;
     border: 2px solid #c69cd9;
     box-shadow: 4px 4px 0 #000;
-    padding: 1rem;
+    padding: 1rem 1rem 1rem 3rem;
     width: 220px;
     position: relative;
     transform-origin: top center;


### PR DESCRIPTION
## Summary
- Use notebook paper styling for chart descriptions
- Add notebook-style paper background to Vision board items

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b4351bfc8321aa530870f6a19a5f