### PR TITLE
style: add notebook paper backgrounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -358,19 +358,19 @@
 
     <section id="tokenomics">
         <h2><i class="fa-solid fa-coins section-icon gold-icon" aria-hidden="true"></i>TOKENOMICS</h2>
-        <p class="total-supply"><span>Total Supply: 92,000,000 thrift tokens.</span><img src="coins/thrift.png" alt="Thrift Token" class="supply-icon"/></p>
+        <p class="total-supply notebook-paper"><span>Total Supply: 92,000,000 thrift tokens.</span><img src="coins/thrift.png" alt="Thrift Token" class="supply-icon"/></p>
         <div class="token-equation">
-            <div class="eq-part">
+            <div class="eq-part notebook-paper">
                 <span class="eq-number">92,000,000,000</span>
                 <span class="eq-label">kg unwanted clothing</span>
             </div>
             <div class="eq-operator">÷</div>
-            <div class="eq-part">
+            <div class="eq-part notebook-paper">
                 <span class="eq-number">1,000</span>
                 <span class="eq-label">kg per token</span>
             </div>
             <div class="eq-operator">=</div>
-            <div class="eq-part">
+            <div class="eq-part notebook-paper">
                 <span class="eq-number">92,000,000<img src="coins/thrift.png" alt="Thrift Token" class="supply-icon"/></span>
                 <span class="eq-label">total tokens</span>
             </div>
@@ -446,11 +446,11 @@
     <section id="roadmap">
         <h2><i class="fa-solid fa-map section-icon" aria-hidden="true"></i>ROADMAP</h2>
         <div class="roadmap-container">
-            <div class="roadmap-phase phase1"><i class="fa-solid fa-coins phase-icon" aria-hidden="true"></i>Phase 1: Token Creation and ICO (6 months)</div>
-            <div class="roadmap-phase phase2"><i class="fa-solid fa-laptop-code phase-icon" aria-hidden="true"></i>Phase 2: dApp Development and AR Integration (12 months)</div>
-            <div class="roadmap-phase phase3"><i class="fa-solid fa-flask phase-icon" aria-hidden="true"></i>Phase 3: Fiber Separation Technology R&amp;D (18 months)</div>
-            <div class="roadmap-phase phase4"><i class="fa-solid fa-store phase-icon" aria-hidden="true"></i>Phase 4: Thrift Network Hubs Deployment (24 months)</div>
-            <div class="roadmap-phase phase5"><i class="fa-solid fa-globe phase-icon" aria-hidden="true"></i>Phase 5: Global Expansion and Ecosystem Growth (36 months)</div>
+            <div class="roadmap-phase phase1 notebook-paper"><i class="fa-solid fa-coins phase-icon" aria-hidden="true"></i>Phase 1: Token Creation and ICO (6 months)</div>
+            <div class="roadmap-phase phase2 notebook-paper"><i class="fa-solid fa-laptop-code phase-icon" aria-hidden="true"></i>Phase 2: dApp Development and AR Integration (12 months)</div>
+            <div class="roadmap-phase phase3 notebook-paper"><i class="fa-solid fa-flask phase-icon" aria-hidden="true"></i>Phase 3: Fiber Separation Technology R&amp;D (18 months)</div>
+            <div class="roadmap-phase phase4 notebook-paper"><i class="fa-solid fa-store phase-icon" aria-hidden="true"></i>Phase 4: Thrift Network Hubs Deployment (24 months)</div>
+            <div class="roadmap-phase phase5 notebook-paper"><i class="fa-solid fa-globe phase-icon" aria-hidden="true"></i>Phase 5: Global Expansion and Ecosystem Growth (36 months)</div>
         </div>
     </section>
 

--- a/styles.css
+++ b/styles.css
@@ -1409,3 +1409,8 @@ footer {
     box-shadow: 0 2px #000;
     text-decoration: none;
 }
+
+/* Notebook paper background */
+.notebook-paper {
+    background: repeating-linear-gradient(#fff, #fff 24px, #e2f0ff 24px, #e2f0ff 25px);
+}


### PR DESCRIPTION
## Summary
- Add reusable `notebook-paper` CSS style with lined paper background
- Apply notebook paper styling to total supply, token equation, and roadmap phase boxes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f2e4b2dc8321ae9ee5df6dc70e55