### PR TITLE
Connect wallet options to providers

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,11 +49,11 @@
         <div class="modal-content">
             <span id="modalClose" class="modal-close">&times;</span>
             <h3>CONNECT WALLET</h3>
-            <button class="wallet-option" data-url="https://bestwallet.com">Best Wallet <i class="fa-solid fa-wallet"></i></button>
-            <button class="wallet-option" data-url="https://walletconnect.com">WalletConnect <i class="fa-solid fa-link"></i></button>
-            <button class="wallet-option" data-url="https://metamask.io/download/">MetaMask <img src="coins/MetaMask.png" alt="MetaMask logo"/></button>
-            <button class="wallet-option" data-url="https://www.base.org/wallet">Base Wallet <i class="fa-solid fa-rocket"></i></button>
-            <button class="wallet-option" data-url="https://www.coinbase.com/wallet">Coinbase Wallet <i class="fa-solid fa-coins"></i></button>
+            <button class="wallet-option" data-wallet="best">Best Wallet <i class="fa-solid fa-wallet"></i></button>
+            <button class="wallet-option" data-wallet="walletconnect">WalletConnect <i class="fa-solid fa-link"></i></button>
+            <button class="wallet-option" data-wallet="metamask">MetaMask <img src="coins/MetaMask.png" alt="MetaMask logo"/></button>
+            <button class="wallet-option" data-wallet="base">Base Wallet <i class="fa-solid fa-rocket"></i></button>
+            <button class="wallet-option" data-wallet="coinbase">Coinbase Wallet <i class="fa-solid fa-coins"></i></button>
             <button class="wallet-option" data-url="https://web3paymentsolutions.io">Pay with Card <i class="fa-solid fa-credit-card"></i></button>
         </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -670,10 +670,55 @@ document.addEventListener("DOMContentLoaded", function () {
         if (e.target === walletInfoModal) walletInfoModal.classList.add("hidden");
     });
 
+    async function connectToWallet(type) {
+        try {
+            const providers = window.ethereum?.providers || [window.ethereum];
+            let provider;
+            switch (type) {
+                case "metamask":
+                    provider = providers?.find(p => p.isMetaMask);
+                    break;
+                case "coinbase":
+                    provider = providers?.find(p => p.isCoinbaseWallet) || window.coinbaseWalletExtension;
+                    break;
+                case "base":
+                    provider = providers?.find(p => p.isBaseWallet || p.isBase);
+                    break;
+                case "walletconnect":
+                    provider = providers?.find(p => p.isWalletConnect);
+                    break;
+                case "best":
+                    provider = providers?.find(p => p.isBestWallet) || window.BestWallet;
+                    break;
+            }
+            if (provider) {
+                await provider.request({ method: "eth_requestAccounts" });
+                walletModal?.classList.add("hidden");
+                return;
+            }
+            const urls = {
+                best: "https://bestwallet.com",
+                walletconnect: "https://walletconnect.com",
+                metamask: "https://metamask.io/download/",
+                base: "https://www.base.org/wallet",
+                coinbase: "https://www.coinbase.com/wallet",
+            };
+            const fallback = urls[type];
+            if (fallback) {
+                window.open(fallback, "_blank", "noopener");
+            }
+        } catch (err) {
+            console.error("Wallet connection failed", err);
+        }
+    }
+
     walletOptions.forEach(option => {
         option.addEventListener("click", () => {
+            const wallet = option.getAttribute("data-wallet");
             const url = option.getAttribute("data-url");
-            if (url) {
+            if (wallet) {
+                connectToWallet(wallet);
+            } else if (url) {
                 window.open(url, "_blank", "noopener");
                 walletModal?.classList.add("hidden");
             }


### PR DESCRIPTION
## Summary
- trigger provider connection for MetaMask, Coinbase, Base and other wallets instead of navigating away
- use data-wallet attributes in modal to pick specific wallet or fall back to download link

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fba83170832191f3b544a87ed137